### PR TITLE
send /bundle requests to backend

### DIFF
--- a/cloudflare/src/index.ts
+++ b/cloudflare/src/index.ts
@@ -37,8 +37,11 @@ async function proxyRequest(r: Request): Promise<Response> {
 
 export function isAPIRequest(requestUrl: string): boolean {
   const parsed = url.parse(requestUrl, true);
-  if (parsed.path.startsWith('/installer')) {
-    return true;
+  if (parsed && parsed.path) {
+    if (parsed.path.startsWith('/installer') ||
+        parsed.path.startsWith('/bundle')) {
+      return true;
+    }
   }
 
   return false;

--- a/cloudflare/src/index_test.ts
+++ b/cloudflare/src/index_test.ts
@@ -47,4 +47,9 @@ describe("isAPIRequest", () => {
     expect(isAPIRequest("https://staging.kurl.sh/installer")).to.equal(true);
   });
 
+  it("is a request for an airgap bundle", async () => {
+
+    expect(isAPIRequest("https://kurl.sh/bundle/latest.tar.gz")).to.equal(true);
+  });
+
 });


### PR DESCRIPTION
Update cloudflare worker logic to route /bundle requests to backend, so that kurl.sh download links will work properly.

