### PR TITLE
Specifying kernel 4.15 or later is required for Ubuntu 16.04

### DIFF
--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -8,7 +8,7 @@ title: "System Requirements"
 
 ## Supported Operating Systems
 
-* Ubuntu 16.04
+* Ubuntu 16.04 (Kernel version >= 4.15)
 * Ubuntu 18.04 (Recommended)
 * CentOS 7.4, 7.5, 7.6
 * RHEL 7.4, 7.5, 7.6


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/8466736/72760308-2aa36400-3b8d-11ea-89b4-0327efafa59e.png)
