### PR TITLE
Updated TLS cert docs to restart kurl-proxy

### DIFF
--- a/src/markdown-pages/install-with-kurl/setup-tls-certs.md
+++ b/src/markdown-pages/install-with-kurl/setup-tls-certs.md
@@ -29,9 +29,9 @@ If you've already gone through the setup process once, and you want to upload ne
 
 `kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1`
 
-<span style="color:red">**Warning: adding this annotation will temporarily create a vulnerability for anyone to nefariously upload TLS certificates.  Once TLS have been uploaded then the vulnerability is closed again.**</span>
+<span style="color:red">**Warning: adding this annotation will temporarily create a vulnerability for anyone to nefariously upload TLS certificates.  Once TLS certificates have been uploaded then the vulnerability is closed again.**</span>
 
-After adding the annotation, you will need to restart the kurl proxy server.  The simplest way to do this is to delete the kurl-proxy pod (the pod will automatically get restarted): 
+After adding the annotation, you will need to restart the kurl proxy server.  The simplest way is to delete the kurl-proxy pod (the pod will automatically get restarted): 
 
 `kubectl delete pods PROXY_SERVER`
 
@@ -41,5 +41,5 @@ The following command should provide the name of the kurl-proxy server:
 
 After the pod has been restarted direct your browser to `http://<ip>:8800` and run through the upload process as described above.  
     
-It's best to complete this process as soon as possible to avoid anyone from nefariously uploading TLS certificates.  After this process has completed, the vulnerability will be closed, and uploading new TLS will be disallowed again.  In order to upload new TLS certs you must repeat the steps above. 
+It's best to complete this process as soon as possible to avoid anyone from nefariously uploading TLS certificates.  After this process has completed, the vulnerability will be closed, and uploading new TLS certificates will be disallowed again.  In order to upload new TLS certificates you must repeat the steps above. 
 <br><br><br>


### PR DESCRIPTION
During a support call with a vendor, I realized I forgot a step in the process to reload new TLS certs.  After the adding the annotation we need to restart kurl-proxy server (pod).  