### PR TITLE
Revert "list Oracle Linux as supported"

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -185,7 +185,6 @@ cat install.sh | sudo bash -s airgap
                     <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal"> Ubuntu 20.04 (Docker version >= 19.03.10) </li>
                     <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal"> CentOS 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (CentOS 8.x requires Containerd) </li>
                     <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal"> RHEL 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (RHEL 8.x requires Containerd) </li>
-                    <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal"> Oracle Linux 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (OL 8.x requires Containerd) </li>
                     <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal"> Amazon Linux 2 </li>
                   </div>
                 </div>

--- a/src/markdown-pages/add-ons/containerd.md
+++ b/src/markdown-pages/add-ons/containerd.md
@@ -9,7 +9,7 @@ addOn: "containerd"
 Containerd is an alternative CRI (Container Runtime Interface) to Docker.
 Please note that containerd must be specified in yaml spec, and that docker must not be present if containerd is.
 
-As CentOS, RHEL and Oracle Linux 8.x do not support Docker, the Containerd CRI is required.
+As CentOS and RHEL 8.x do not support Docker, the Containerd CRI is required.
 
 ## Advanced Install Options
 

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -13,7 +13,6 @@ title: "System Requirements"
 * Ubuntu 20.04 (Docker version >= 19.03.10)
 * CentOS 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (CentOS 8.x requires Containerd)
 * RHEL 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (RHEL 8.x requires Containerd)
-* Oracle Linux 7.4, 7.5, 7.6, 7.7, 7.8, 7.9, 8.1, 8.2, 8.3 (OL 8.x requires Containerd)
 * Amazon Linux 2
 
 ## Minimum System Requirements


### PR DESCRIPTION
Reverts replicatedhq/kurl.sh#369

instead, we will list this as supported once it's in testgrid