### PR TITLE
Release v2021.05.26 (#427)

### DIFF
--- a/src/release-notes/v2021.05.26-0.md
+++ b/src/release-notes/v2021.05.26-0.md
@@ -1,0 +1,8 @@
+---
+date: "2021-05-26"
+version: "v2021.05.26-1"
+weight: 202105261
+---
+
+### <span class="label label-orange">Bug Fixes</span>
+- Fixed release generator

--- a/src/release-notes/v2021.05.26-1.md
+++ b/src/release-notes/v2021.05.26-1.md
@@ -1,0 +1,17 @@
+---
+date: "2021-05-26"
+version: "v2021.05.26-1"
+weight: 202105261
+---
+
+### <span class="label label-green">New Features</span>
+- Added Kubernetes versions 1.21.1, 1.20.7, 1.19.11 and 1.18.19
+- Added [Rook add-on](/docs/add-ons/rook) version 1.5.11
+- Added [Prometheus add-on](/docs/add-ons/prometheus) version 0.47.1-16.0.1
+
+### <span class="label label-blue">Improvements</span>
+- The [Containerd add-on](/docs/add-ons/containerd) will now be upgraded to conform to the latest kURL spec installed
+- The version of runC included with Docker and Containerd has been upgraded to [v1.0.0-rc95](https://github.com/opencontainers/runc/releases/tag/v1.0.0-rc95)
+
+### <span class="label label-orange">Bug Fixes</span>
+- Fixed an issue that caused the Grafana dashboard to fail to show graphs due to a misconfigured Prometheus service URL

--- a/src/release-notes/v2021.05.26-2.md
+++ b/src/release-notes/v2021.05.26-2.md
@@ -1,0 +1,8 @@
+---
+date: "2021-05-26"
+version: "v2021.05.26-2"
+weight: 202105262
+---
+
+### <span class="label label-orange">Bug Fixes</span>
+- Fixed an issue that caused installations on Oracle Linux 8.4 to fail.


### PR DESCRIPTION
* Release v2021.05.NEXT-0

* Kubernetes 1 18 19 1 19 11 1 20 7 1 21 1 [ch34349]

* Rook 1 5 11 [ch34350]

* Prometheus 0 47 1 [ch34351]

* Containerd and runc upgrades [ch29921] [ch33800]

* Grafana Dashboard unable to connect to Prometheus data store #1595

* fixes

* No periods

* Add v2021.05.26-1

* add v2021.05.26-2 release notes

Co-authored-by: Andrew Reed <andrew@replicated.com>
Co-authored-by: Andrew Lavery <laverya@umich.edu>