### PR TITLE
Update patch notes for kURL (#459)

### DIFF
--- a/src/release-notes/v2021.06.22-0.md
+++ b/src/release-notes/v2021.06.22-0.md
@@ -1,0 +1,9 @@
+---
+date: "2021-06-22"
+version: "v2021.06.22-0"
+weight: 202106220
+---
+
+### <span class="label label-orange">Bug Fixes</span>
+- Fixed an issue that caused Rook-Ceph to have insecure connection claims. See [CVE-2021-20288](https://docs.ceph.com/en/latest/security/CVE-2021-20288/) for details.
+- A new [Rook](https://kurl.sh/docs/add-ons/rook) add-on version 1.0.4-14.2.21 has been added with an upgraded Ceph version 14.2.21.


### PR DESCRIPTION
* Update patch notes for kURL

* added release note for Rook-Ceph 1.0.4 fix

* Update v2021.06.22-0.md

Co-authored-by: John Murphy <john@replicated.com>
Co-authored-by: emosbaugh <ethan@replicated.com>