### PR TITLE
Revert KOTS URL change

### DIFF
--- a/src/markdown-pages/add-ons/kotsadm.md
+++ b/src/markdown-pages/add-ons/kotsadm.md
@@ -1,5 +1,5 @@
 ---
-path: "/docs/add-ons/kots"
+path: "/docs/add-ons/kotsadm"
 date: "2020-04-23"
 linktitle: "KOTS Add-On"
 weight: 38

--- a/src/release-notes/v2021.05.07-1.md
+++ b/src/release-notes/v2021.05.07-1.md
@@ -5,7 +5,7 @@ weight: 202105071
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.41.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.41.0
 
 ### <span class="label label-blue">Improvements</span>
 - Allow the `WEAVE_TAG` environment variable to be specified to pin the Weave version when running the [reset task](/docs/install-with-kurl/adding-nodes#resetting-a-node).

--- a/src/release-notes/v2021.05.14-1.md
+++ b/src/release-notes/v2021.05.14-1.md
@@ -5,4 +5,4 @@ weight: 202105141
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.41.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.41.1

--- a/src/release-notes/v2021.05.21-1.md
+++ b/src/release-notes/v2021.05.21-1.md
@@ -5,4 +5,4 @@ weight: 202105211
 ---
 
 ### <span class="label label-blue">Improvements</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.42.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.42.0

--- a/src/release-notes/v2021.05.24-0.md
+++ b/src/release-notes/v2021.05.24-0.md
@@ -6,4 +6,4 @@ weight: 202105240
 
 ### <span class="label label-green">New Features</span>
 - Added the ability to configure proxies for Velero backups.
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.42.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.42.1

--- a/src/release-notes/v2021.05.28-1.md
+++ b/src/release-notes/v2021.05.28-1.md
@@ -5,7 +5,7 @@ weight: 202105281
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.43.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.43.0
 
 ### <span class="label label-blue">Improvements</span>
 - A host preflight check for the [Longhorn add-on](/docs/add-ons/longhorn) will ensure sufficient disk space is available in /var/lib/longhorn

--- a/src/release-notes/v2021.06.04-0.md
+++ b/src/release-notes/v2021.06.04-0.md
@@ -5,7 +5,7 @@ weight: 202106040
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.43.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.43.1
 - Added [EKCO add-on](/docs/add-ons/ekco) version 0.10.2 with support for Longhorn PVCs in the node shutdown script
 - Added [Prometheus add-on](/docs/add-ons/prometheus) version 0.48.0-16.1.2
 

--- a/src/release-notes/v2021.06.08-0.md
+++ b/src/release-notes/v2021.06.08-0.md
@@ -5,4 +5,4 @@ weight: 202106080
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.43.2
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.43.2

--- a/src/release-notes/v2021.06.11-0.md
+++ b/src/release-notes/v2021.06.11-0.md
@@ -5,4 +5,4 @@ weight: 202106110
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.44.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.44.0

--- a/src/release-notes/v2021.06.15-0.md
+++ b/src/release-notes/v2021.06.15-0.md
@@ -5,7 +5,7 @@ weight: 202106150
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.44.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.44.1
 - Added a new field, kurl.InstallerVersion, that allows [pinning the kURL installer version](/docs/install-with-kurl/#versioned-releases).
 
 ### <span class="label label-blue">Improvements</span>

--- a/src/release-notes/v2021.06.25-0.md
+++ b/src/release-notes/v2021.06.25-0.md
@@ -6,7 +6,7 @@ weight: 202106250
 
 ### <span class="label label-green">New Features</span>
 - Added support for Kubernetes versions 1.21.2, 1.20.8, 1.19.12 and 1.18.20
-- Added [KOTS](https://kurl.sh/docs/add-ons/kots) add-on version 1.45.0
+- Added [KOTS](https://kurl.sh/docs/add-ons/kotsadm) add-on version 1.45.0
 - Added [Containerd](https://kurl.sh/docs/add-ons/containerd) add-on version 1.4.6
 - Added [Contour](https://kurl.sh/docs/add-ons/contour) add-on version 1.16.0
 - Added [EKCO](https://kurl.sh/docs/add-ons/ekco) add-on version 0.10.3

--- a/src/release-notes/v2021.07.02-0.md
+++ b/src/release-notes/v2021.07.02-0.md
@@ -5,7 +5,7 @@ weight: 202107020
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.46.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.46.0
 
 ### <span class="label label-orange">Bug Fixes</span>
 - Fixed CVE-2021-20288 Rook 1.5.11 and 1.0.4-14.2.21

--- a/src/release-notes/v2021.07.13-0.md
+++ b/src/release-notes/v2021.07.13-0.md
@@ -6,7 +6,7 @@ weight: 202107130
 
 ### <span class="label label-green">New Features</span>
 - Preflight results will now be stored on the host in the directory /var/lib/kurl/host-preflights.
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.47.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.47.0
 
 ### <span class="label label-blue">Improvements</span>
 - When downloading a bundle from the kURL server, the bundle creation process will fail early in the situation where one of the layers is unavailable, instead of returning a partial bundle.

--- a/src/release-notes/v2021.07.16-0.md
+++ b/src/release-notes/v2021.07.16-0.md
@@ -5,7 +5,7 @@ weight: 202107160
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.47.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.47.1
 
 ### <span class="label label-blue">Improvements</span>
 - The [containerd add-on](/docs/add-ons/containerd) will check XFS filesystems have ftype enabled before attempting to install.

--- a/src/release-notes/v2021.07.19-0.md
+++ b/src/release-notes/v2021.07.19-0.md
@@ -5,7 +5,7 @@ weight: 202107190
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.47.2
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.47.2
 - The [Rook add-on's](/docs/add-ons/rook) object store can be migrated to [MinIO](/docs/add-ons/minio) with the `migrate-rgw-to-minio` task.
 
 ### <span class="label label-blue">Improvements</span>

--- a/src/release-notes/v2021.07.23-1.md
+++ b/src/release-notes/v2021.07.23-1.md
@@ -5,7 +5,7 @@ weight: 202107231
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.47.3
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.47.3
 - Added [Velero add-on](/docs/add-ons/velero) version 1.6.2
 - Added [Longhorn add-on](/docs/add-ons/longhorn) version 1.1.2
 - Added [Prometheus add-on](/docs/add-ons/prometheus) version 0.49.0-17.0.0

--- a/src/release-notes/v2021.07.30-1.md
+++ b/src/release-notes/v2021.07.30-1.md
@@ -5,4 +5,4 @@ weight: 202107301
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.48.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.48.0

--- a/src/release-notes/v2021.08.03-0.md
+++ b/src/release-notes/v2021.08.03-0.md
@@ -5,7 +5,7 @@ weight: 202108030
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.48.1
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.48.1
 
 ### <span class="label label-orange">Bug Fixes</span>
 - Fixed case where kotsadm config would get overriden

--- a/src/release-notes/v2021.08.06-0.md
+++ b/src/release-notes/v2021.08.06-0.md
@@ -5,4 +5,4 @@ weight: 202108060
 ---
 
 ### <span class="label label-green">New Features</span>
-- Added [KOTS add-on](/docs/add-ons/kots) version 1.49.0
+- Added [KOTS add-on](/docs/add-ons/kotsadm) version 1.49.0


### PR DESCRIPTION
A previous change to make the KOTS add-on URL match brand guidelines broke the KOTS "Learn more" link on the add-ons page.