### PR TITLE
Release notes for v2022.02.17-0

### DIFF
--- a/src/release-notes/v2022.02.17-0.md
+++ b/src/release-notes/v2022.02.17-0.md
@@ -1,0 +1,18 @@
+---
+date: "2022-02-17"
+version: "v2022.02.17-0"
+weight: 202202170
+---
+
+### <span class="label label-green">New Features</span>
+- Introduces beta support for the [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) add-ons.
+- Introduces beta support for a [single-node optimized installer spec](/docs/create-installer/single-node-optimized), using either [K3s](/docs/add-ons/k3s) or [RKE2](/docs/add-ons/rke2).
+- The [KOTS](/docs/add-ons/kostadm) add-on no longer includes the MinIO image.
+
+### <span class="label label-blue">Improvements</span>
+- Auto-detect host's private IP on subsequent runs of installer script.
+
+### <span class="label label-orange">Bug Fixes</span>
+- Fixes an erroneous host preflight failure when using EKCO's [internal load balancer](/docs/add-ons/ekco#internal-load-balancer).
+- Fixes a bug that caused containerd to fail with x509 errors when pulling images from local kURL registry.
+- Fixes a bug that resulted in `kurl-config` ConfigMap to be missing when using [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) distros.

--- a/src/release-notes/v2022.02.17-0.md
+++ b/src/release-notes/v2022.02.17-0.md
@@ -5,14 +5,14 @@ weight: 202202170
 ---
 
 ### <span class="label label-green">New Features</span>
-- Introduces beta support for the [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) add-ons.
-- Introduces beta support for a [single-node optimized installer spec](/docs/create-installer/single-node-optimized), using either [K3s](/docs/add-ons/k3s) or [RKE2](/docs/add-ons/rke2).
+- (Beta) Introduces support for the [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) add-ons.
+- (Beta) Introduces support for a [single-node optimized installer specification](/docs/create-installer/single-node-optimized), using either [K3s](/docs/add-ons/k3s) or [RKE2](/docs/add-ons/rke2).
 - The [KOTS](/docs/add-ons/kostadm) add-on no longer includes the MinIO image.
 
 ### <span class="label label-blue">Improvements</span>
-- Auto-detect host's private IP on subsequent runs of installer script.
+- Automatic detection of the host's private IP on subsequent runs of the installation script.
 
 ### <span class="label label-orange">Bug Fixes</span>
 - Fixes an erroneous host preflight failure when using EKCO's [internal load balancer](/docs/add-ons/ekco#internal-load-balancer).
-- Fixes a bug that caused containerd to fail with x509 errors when pulling images from local kURL registry.
-- Fixes a bug that resulted in `kurl-config` ConfigMap to be missing when using [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) distros.
+- Fixes a bug that caused containerd to fail with x509 errors when pulling images from the local kURL registry.
+- Fixes a bug that resulted in the `kurl-config` ConfigMap to be missing when using [K3s](/docs/add-ons/k3s) and [RKE2](/docs/add-ons/rke2) distributions.


### PR DESCRIPTION
Release notes for kURL.  kURL source code diff can be seen [here](https://github.com/replicatedhq/kURL/compare/v2022.02.11-1...main)