### PR TITLE
add --overwrite flag to the kotsadm-tls secret annotation command

### DIFF
--- a/src/markdown-pages/install-with-kurl/setup-tls-certs.md
+++ b/src/markdown-pages/install-with-kurl/setup-tls-certs.md
@@ -27,7 +27,7 @@ kURL will set up a Kubernetes secret called `kotsadm-tls`.  The secret stores th
 
 If you've already gone through the setup process once, and you want to upload new TLS certificates, you must run this command to restore the ability to upload new TLS certificates:
 
-`kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1`
+`kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1 --overwrite`
 
 <span style="color:red">**Warning: adding this annotation will temporarily create a vulnerability for an attacker to maliciously upload TLS certificates.  Once TLS certificates have been uploaded then the vulnerability is closed again.**</span>
 


### PR DESCRIPTION
```bash
$ kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1
error: --overwrite is false but found the following declared annotation(s): 'acceptAnonymousUploads' already has a value (0)
```

```bash
$ kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1 --overwrite
secret/kotsadm-tls annotated
```