### PR TITLE
44697 adds info about adv option syntax

### DIFF
--- a/src/markdown-pages/install-with-kurl/advanced-options.md
+++ b/src/markdown-pages/install-with-kurl/advanced-options.md
@@ -21,6 +21,8 @@ For example, the following command installs kURL with the `force-reapply-addons`
 curl https://kurl.sh/latest | sudo bash -s force-reapply-addons
 ```
 
+For more information about installing with kURL with advanced options, see [Install with kURL](https://kurl.sh/docs/install-with-kurl/).
+
 The install scripts are idempotent. Re-run the scripts with different flags to change the behavior of the installer.
 
 ## Reference

--- a/src/markdown-pages/install-with-kurl/advanced-options.md
+++ b/src/markdown-pages/install-with-kurl/advanced-options.md
@@ -6,7 +6,24 @@ linktitle: "Advanced Options"
 title: "Advanced Options"
 ---
 
+## Syntax for Advanced Options
+
+To include advanced options in the kURL installation script, use the following syntax with `-s` before the advanced option flag:
+
+```
+curl https://kurl.sh/latest | sudo bash -s ADVANCED_FLAG
+```
+Where `ADVANCED_FLAG` is the flag for the advanced option.
+
+For example, the following command installs kURL with the `force-reapply-addons` option enabled:
+
+```
+curl https://kurl.sh/latest | sudo bash -s force-reapply-addons
+```
+
 The install scripts are idempotent. Re-run the scripts with different flags to change the behavior of the installer.
+
+## Reference
 
 | Flag                             | Usage                                                                                                             |
 | -------------------------------- | ----------------------------------------------------------------------------------------------------------------  |


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/44697/explain-s-syntax-on-adv-options-page-in-kurl-docs

Addresses feedback from SwaggerHub: https://replicated.slack.com/archives/C02BPJQQP28/p1647003261950369

Preview: https://deploy-preview-732--kurlsh-staging.netlify.app/docs/install-with-kurl/advanced-options/