### PR TITLE
DRAFT - 48730: Host Preflight Docs Incorrect

### DIFF
--- a/src/markdown-pages/create-installer/host-preflights/index.md
+++ b/src/markdown-pages/create-installer/host-preflights/index.md
@@ -7,7 +7,7 @@ title: "Customizing Host Preflights"
 ---
 
 While there are [default host preflight checks](/docs/install-with-kurl/host-preflights) that kURL runs during an installation or upgrade, these host preflight checks are customizable.
-There are two mechanisms for customizing host preflight checks: 
+There are two mechanisms for customizing host preflight checks:
 * Supplying additional host preflight checks as part of the kURL installer spec
 * Disabling the default host preflight checks
 
@@ -22,7 +22,7 @@ For examples of host preflight specs, see the following sections on [reproducing
 
 ## Excluding the Default Host Preflight Checks
 
-The default host preflight checks can be excluded by setting the `spec.kurl.excludeBuiltinHostPreflights` field to `true`. See the [kURL add-on docs](/docs/add-ons/kurl) for additional information.
+The default host preflight checks can be excluded by setting the `spec.kurl.excludeBuiltinHostPreflights` field to `true`.
 
 ## Modifying the Default Host Preflight Checks
 
@@ -37,7 +37,7 @@ The add-on host preflight checks can be found in directories that are specific t
 
 #### Finding the Add-On Host Preflight Checks
 
-For each of the add-ons that you are using that have default host preflight checks: 
+For each of the add-ons that you are using that have default host preflight checks:
     1. Go to the add-on directory linked below
     1. Choose the directory for the appropriate version of that add-on
     1. Find the `host-preflight.yaml` file

--- a/src/markdown-pages/install-with-kurl/host-preflights.md
+++ b/src/markdown-pages/install-with-kurl/host-preflights.md
@@ -12,12 +12,11 @@ These checks can also run conditionally, depending on whether the installer is p
 
 The installer has default host preflight checks that run to ensure that certain conditions are met (such as supported operating systems, disk usage, and so on).
 The default host preflight checks are designed and maintained to help ensure the successful installation and ongoing health of the cluster.
-The default preflight checks are also customizable. New host preflight checks can be added to run in addition to the defaults, or the default checks can be disabled to allow for a new set of host preflight checks to run instead. 
+The default preflight checks are also customizable. New host preflight checks can be added to run in addition to the defaults, or the default checks can be disabled to allow for a new set of host preflight checks to run instead.
 For more information, see [customizing host preflight checks](/docs/create-installer/host-preflights).
 
-Host prelight failures block the installation from continuing and exit with a non-zero return code. 
+Host prelight failures block the installation from continuing and exit with a non-zero return code.
 This behavior can be changed as follows:
-* Failures can be bypassed with the [`host-preflight-ignore` flag](/docs/install-with-kurl/advanced-options). 
 * For a more conservative approach, the [`host-preflight-enforce-warnings` flag](/docs/install-with-kurl/advanced-options) can be used to block the installation on warnings.
 * The [`exclude-builtin-host-preflights` flag](/docs/install-with-kurl/advanced-options) can be used to skip the default host preflight checks and run only the custom checks.
 


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/48730/kurl-docs-excluding-host-preflight-is-incorrect