### PR TITLE
add 'beta' to aws add-on titles

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Before you are able to run this locally you need to have NodeJS above v.8.12.
 
 ## Updating documentation flags 
 
-1. When updating add ons flaga JSON should be updated (`/static/versionDetails.json`). 
+1. When updating add-ons flags JSON should be updated (`/static/versionDetails.json`). 
 2. In a markdown file those flags should be called as `flags-table`.
 
 ## Releasing the documentation

--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -1156,7 +1156,7 @@ class Kurlsh extends React.Component {
                       />
                       <span className="icon u-rke2 u-marginBottom--small" />
                       <div className="flex flex-column u-marginLeft--15 u-marginTop--small">
-                        <div className="FormLabel "> RKE2 (Beta) </div>
+                        <div className="FormLabel "> RKE2 <span className="prerelease-tag sidebar beta">beta</span> </div>
                         <div className={`SelectVersion flex flex1 ${!this.state.isAddOnChecked["rke2"] && "disabled"}`} style={{ width: "200px" }}>
                           <span className="flex alignItems--center u-color--fiord u-fontSize--normal versionLabel"> {!this.state.isAddOnChecked["rke2"] ? "Version None" : "Version"} </span>
                           <Select
@@ -1186,7 +1186,7 @@ class Kurlsh extends React.Component {
                       />
                       <span className="icon u-k3s u-marginBottom--small" />
                       <div className="flex flex-column u-marginLeft--15 u-marginTop--small">
-                        <div className="FormLabel "> K3s (Beta) </div>
+                        <div className="FormLabel "> K3s <span className="prerelease-tag sidebar beta">beta</span> </div>
                         <div className={`SelectVersion flex flex1 ${!this.state.isAddOnChecked["k3s"] && "disabled"}`} style={{ width: "200px" }}>
                           <span className="flex alignItems--center u-color--fiord u-fontSize--normal versionLabel"> {!this.state.isAddOnChecked["k3s"] ? "Version None" : "Version"} </span>
                           <Select
@@ -1944,7 +1944,7 @@ class Kurlsh extends React.Component {
                       />
                       <span className="icon u-aws u-marginBottom--small" />
                       <div className="flex flex-column u-marginLeft--15 u-marginTop--small">
-                        <div className="FormLabel"> AWS (Beta) </div>
+                        <div className="FormLabel"> AWS <span className="prerelease-tag sidebar beta">beta</span> </div>
                         <div className="flex flex1 alignItems--center">
                           <div className={`SelectVersion flex flex1 ${!this.state.isAddOnChecked["aws"] && "disabled"}`} style={{ width: "200px" }}>
                             <span className="flex alignItems--center u-color--fiord u-fontSize--normal versionLabel"> {!this.state.isAddOnChecked["aws"] ? "Version None" : "Version"} </span>

--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -1944,7 +1944,7 @@ class Kurlsh extends React.Component {
                       />
                       <span className="icon u-aws u-marginBottom--small" />
                       <div className="flex flex-column u-marginLeft--15 u-marginTop--small">
-                        <div className="FormLabel"> AWS </div>
+                        <div className="FormLabel"> AWS (Beta) </div>
                         <div className="flex flex1 alignItems--center">
                           <div className={`SelectVersion flex flex1 ${!this.state.isAddOnChecked["aws"] && "disabled"}`} style={{ width: "200px" }}>
                             <span className="flex alignItems--center u-color--fiord u-fontSize--normal versionLabel"> {!this.state.isAddOnChecked["aws"] ? "Version None" : "Version"} </span>

--- a/src/components/SupportedAddOns.js
+++ b/src/components/SupportedAddOns.js
@@ -163,14 +163,18 @@ class SupportedAddOns extends React.Component {
     const activeSupportedVersionCategory = categoryVersionsToShow.find(c => c.name === addOn.name);
     const versions = supportedVersions[addOn.name];
 
-
     return (
       <div className={`${isMobile ? "mobileAddOns--wrapper" : filteredCategories ? "AddOns--wrapper fixedHeight flex flex-column" : "AddOns--wrapper flex flex-column"}`} key={`${addOn}-${i}`}>
         <div className="addOnsBackground flex alignItems--center">
           <div className="flex flex1 alignItems--center">
             <span className={`icon u-${addOn.name === "ekco" || addOn.name === "metrics-server" ? "kubernetes" : addOn.name === "cert-manager" ? "certManager" : addOn.name.toLowerCase()} u-marginBottom--small`}></span>
             <div className="flex-column">
-              <span className="u-fontSize--largest u-fontWeight--medium u-color--tuna  u-marginLeft--10">{this.generateVersionName(addOn.name)}</span>
+              <span className="u-fontSize--largest u-fontWeight--medium u-color--tuna  u-marginLeft--10">
+                {this.generateVersionName(addOn.name)}
+                {addOn.name === "aws" && (
+                  <span className="prerelease-tag sidebar beta">beta</span>
+                )}
+              </span>
               <div className="flex flex1 u-marginTop--small">
                 {addOn.fulfills.map((category, i) => {
                   return (

--- a/src/components/shared/SidebarFileTree.js
+++ b/src/components/shared/SidebarFileTree.js
@@ -4,10 +4,17 @@ import { Link, navigate } from "gatsby";
 import "../../scss/components/shared/SidebarFileTree.scss";
 
 function titleize(string) {
-  return string
+  const title = string
     .split("-")
     .map(s => s[0].toUpperCase() + s.slice(1))
     .join(" ");
+  if (title === "Add Ons") {
+    return "Add-Ons";
+  }
+  if (title === "Add On Author") {
+    return "Add-On Author";
+  }
+  return title;
 }
 
 export default class SidebarFileTree extends Component {

--- a/src/markdown-pages/add-ons/antrea.md
+++ b/src/markdown-pages/add-ons/antrea.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/antrea"
 date: "2020-05-13"
-linktitle: "Antrea Add-On"
+linktitle: "Antrea"
 weight: 30
 title: "Antrea Add-On"
 addOn: "antrea"

--- a/src/markdown-pages/add-ons/aws.md
+++ b/src/markdown-pages/add-ons/aws.md
@@ -1,9 +1,9 @@
 ---
 path: "/docs/add-ons/aws"
 date: "2022-05-10"
-linktitle: "AWS Add-On"
+linktitle: "AWS Add-On (Beta)"
 weight: 31
-title: "AWS Add-On"
+title: "AWS Add-On (Beta)"
 addOn: "aws"
 ---
 

--- a/src/markdown-pages/add-ons/aws.md
+++ b/src/markdown-pages/add-ons/aws.md
@@ -1,10 +1,11 @@
 ---
 path: "/docs/add-ons/aws"
 date: "2022-05-10"
-linktitle: "AWS Add-On (Beta)"
+linktitle: "AWS Add-On"
 weight: 31
-title: "AWS Add-On (Beta)"
+title: "AWS Add-On"
 addOn: "aws"
+isBeta: true
 ---
 
 The AWS add-on enables the Amazon Web Services (AWS) cloud provider integration with the Kubernetes (kubeadm) kURL add-on. For information about the kubeadm add-on, see [Kubernetes (kubeadm) Add-On](/docs/addon-ons/kubernetes).

--- a/src/markdown-pages/add-ons/aws.md
+++ b/src/markdown-pages/add-ons/aws.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/aws"
 date: "2022-05-10"
-linktitle: "AWS Add-On"
+linktitle: "AWS"
 weight: 31
 title: "AWS Add-On"
 addOn: "aws"

--- a/src/markdown-pages/add-ons/cert-manager.md
+++ b/src/markdown-pages/add-ons/cert-manager.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/cert-manager"
 date: "2020-11-02"
-linktitle: "Cert Manager Add-On"
+linktitle: "Cert Manager"
 weight: 32
 title: "Cert Manager Add-On"
 addOn: "certManager"

--- a/src/markdown-pages/add-ons/collectd.md
+++ b/src/markdown-pages/add-ons/collectd.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/collectd"
 date: "2020-11-02"
-linktitle: "Collectd Add-On"
+linktitle: "Collectd"
 weight: 33
 title: "Collectd Add-On"
 addOn: "collectd"

--- a/src/markdown-pages/add-ons/containerd.md
+++ b/src/markdown-pages/add-ons/containerd.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/containerd"
 date: "2020-06-13"
-linktitle: "Containerd Add-On"
+linktitle: "Containerd"
 weight: 34
 title: "Containerd Add-On"
 addOn: "containerd"

--- a/src/markdown-pages/add-ons/contour.md
+++ b/src/markdown-pages/add-ons/contour.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/contour"
 date: "2021-01-20"
-linktitle: "Contour Add-On"
+linktitle: "Contour"
 weight: 35
 title: "Contour Add-On"
 addOn: "contour"

--- a/src/markdown-pages/add-ons/docker.md
+++ b/src/markdown-pages/add-ons/docker.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/docker"
 date: "2020-05-13"
-linktitle: "Docker Add-On"
+linktitle: "Docker"
 weight: 36
 title: "Docker Add-On"
 addOn: "docker"

--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/ekco"
 date: "2020-02-27"
-linktitle: "EKCO Add-On"
+linktitle: "EKCO"
 weight: 37
 title: "Embedded kURL Cluster Operator (EKCO) Add-On"
 addOn: "ekco"

--- a/src/markdown-pages/add-ons/firewalld.md
+++ b/src/markdown-pages/add-ons/firewalld.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/firewalld"
 date: "2020-05-01"
-linktitle: "Firewalld Add-On"
+linktitle: "Firewalld"
 weight: 38
 title: "Firewalld Add-On"
 addOn: "firewalld"

--- a/src/markdown-pages/add-ons/fluentd.md
+++ b/src/markdown-pages/add-ons/fluentd.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/fluentd"
 date: "2019-02-20"
-linktitle: "Fluentd Add-On"
+linktitle: "Fluentd"
 weight: 39
 title: "Fluentd Add-On"
 addOn: "fluentd"

--- a/src/markdown-pages/add-ons/goldpinger.md
+++ b/src/markdown-pages/add-ons/goldpinger.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/goldpinger"
 date: "2021-06-24"
-linktitle: "Goldpinger Add-On"
+linktitle: "Goldpinger"
 weight: 40
 title: "Goldpinger Add-On"
 addOn: "goldpinger"

--- a/src/markdown-pages/add-ons/iptables.md
+++ b/src/markdown-pages/add-ons/iptables.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/iptables"
 date: "2020-05-01"
-linktitle: "Iptables Add-On"
+linktitle: "Iptables"
 weight: 41
 title: "Iptables Add-On"
 addOn: "iptables"

--- a/src/markdown-pages/add-ons/k3s.md
+++ b/src/markdown-pages/add-ons/k3s.md
@@ -1,10 +1,11 @@
 ---
 path: "/docs/add-ons/k3s"
 date: "2021-02-18"
-linktitle: "K3s Add-On (Beta)"
+linktitle: "K3s Add-On"
 weight: 42
-title: "K3s Add-On (Beta)"
+title: "K3s Add-On"
 addOn: "k3s"
+isBeta: true
 ---
 
 [K3s](https://k3s.io/) is a lightweight Kubernetes distribution built by Rancher for Internet of Things (IoT) and edge computing.

--- a/src/markdown-pages/add-ons/k3s.md
+++ b/src/markdown-pages/add-ons/k3s.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/k3s"
 date: "2021-02-18"
-linktitle: "K3s Add-On"
+linktitle: "K3s"
 weight: 42
 title: "K3s Add-On"
 addOn: "k3s"

--- a/src/markdown-pages/add-ons/kotsadm.md
+++ b/src/markdown-pages/add-ons/kotsadm.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/kotsadm"
 date: "2020-04-23"
-linktitle: "KOTS Add-On"
+linktitle: "KOTS"
 weight: 43
 title: "KOTS Add-On"
 addOn: "kotsadm"

--- a/src/markdown-pages/add-ons/kubernetes.md
+++ b/src/markdown-pages/add-ons/kubernetes.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/kubernetes"
 date: "2021-02-18"
-linktitle: "Kubernetes (kubeadm) Add-On"
+linktitle: "Kubernetes (kubeadm)"
 weight: 44
 title: "Kubernetes (kubeadm) Add-On"
 addOn: "kubernetes"

--- a/src/markdown-pages/add-ons/kurl.md
+++ b/src/markdown-pages/add-ons/kurl.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/kurl"
 date: "2020-05-01"
-linktitle: "Kurl Add-On"
+linktitle: "Kurl"
 weight: 45
 title: "Kurl Add-On"
 addOn: "kurl"

--- a/src/markdown-pages/add-ons/longhorn.md
+++ b/src/markdown-pages/add-ons/longhorn.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/longhorn"
 date: "2021-03-12"
-linktitle: "Longhorn Add-On"
+linktitle: "Longhorn"
 weight: 46
 title: "Longhorn Add-On"
 addOn: "longhorn"

--- a/src/markdown-pages/add-ons/metrics-server.md
+++ b/src/markdown-pages/add-ons/metrics-server.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/metrics-server"
 date: "2020-11-02"
-linktitle: "Metrics Server Add-On"
+linktitle: "Metrics Server"
 weight: 47
 title: "Metrics Server Add-On"
 addOn: "metricsServer"

--- a/src/markdown-pages/add-ons/minio.md
+++ b/src/markdown-pages/add-ons/minio.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/minio"
 date: "2021-01-28"
-linktitle: "MinIO Add-On"
+linktitle: "MinIO"
 weight: 48
 title: "MinIO Add-On"
 addOn: "minio"

--- a/src/markdown-pages/add-ons/openebs.md
+++ b/src/markdown-pages/add-ons/openebs.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/openebs"
 date: "2019-02-20"
-linktitle: "OpenEBS Add-On"
+linktitle: "OpenEBS"
 weight: 49
 title: "OpenEBS Add-On"
 addOn: "openebs"

--- a/src/markdown-pages/add-ons/prometheus.md
+++ b/src/markdown-pages/add-ons/prometheus.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/prometheus"
 date: "2020-05-13"
-linktitle: "Prometheus Add-On"
+linktitle: "Prometheus"
 weight: 50
 title: "Prometheus Add-On"
 addOn: "prometheus"

--- a/src/markdown-pages/add-ons/registry.md
+++ b/src/markdown-pages/add-ons/registry.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/registry"
 date: "2020-05-13"
-linktitle: "Registry Add-On"
+linktitle: "Registry"
 weight: 51
 title: "Registry Add-On"
 addOn: "registry"

--- a/src/markdown-pages/add-ons/rke2.md
+++ b/src/markdown-pages/add-ons/rke2.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/rke2"
 date: "2021-02-18"
-linktitle: "RKE2 Add-On"
+linktitle: "RKE2"
 weight: 52
 title: "RKE2 Add-On"
 addOn: "rke2"

--- a/src/markdown-pages/add-ons/rke2.md
+++ b/src/markdown-pages/add-ons/rke2.md
@@ -1,10 +1,11 @@
 ---
 path: "/docs/add-ons/rke2"
 date: "2021-02-18"
-linktitle: "RKE2 Add-On (Beta)"
+linktitle: "RKE2 Add-On"
 weight: 52
-title: "RKE2 Add-On (Beta)"
+title: "RKE2 Add-On"
 addOn: "rke2"
+isBeta: true
 ---
 
 [RKE2](https://rke2.io/), also known as RKE Government, is a fully-conformant Kubernetes distribution from Rancher.

--- a/src/markdown-pages/add-ons/rook.md
+++ b/src/markdown-pages/add-ons/rook.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/rook"
 date: "2020-04-01"
-linktitle: "Rook Add-On"
+linktitle: "Rook"
 weight: 53
 title: "Rook Add-On"
 addOn: "rook"

--- a/src/markdown-pages/add-ons/selinux.md
+++ b/src/markdown-pages/add-ons/selinux.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/selinux"
 date: "2020-05-01"
-linktitle: "SELinux Add-On"
+linktitle: "SELinux"
 weight: 54
 title: "SELinux Add-On"
 addOn: "selinux"

--- a/src/markdown-pages/add-ons/sonobuoy.md
+++ b/src/markdown-pages/add-ons/sonobuoy.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/sonobuoy"
 date: "2021-04-09"
-linktitle: "Sonobuoy Add-On"
+linktitle: "Sonobuoy"
 weight: 55
 title: "Sonobuoy Add-On"
 addOn: "Sonobuoy"

--- a/src/markdown-pages/add-ons/ufw.md
+++ b/src/markdown-pages/add-ons/ufw.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/ufw"
 date: "2021-04-13"
-linktitle: "UFW Add-On"
+linktitle: "UFW"
 weight: 56
 title: "UFW Add-On"
 addOn: "ufw"

--- a/src/markdown-pages/add-ons/velero.md
+++ b/src/markdown-pages/add-ons/velero.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/velero"
 date: "2019-11-20"
-linktitle: "Velero Add-On"
+linktitle: "Velero"
 weight: 57
 title: "Velero Add-On"
 addOn: "velero"

--- a/src/markdown-pages/add-ons/weave.md
+++ b/src/markdown-pages/add-ons/weave.md
@@ -1,7 +1,7 @@
 ---
 path: "/docs/add-ons/weave"
 date: "2020-05-13"
-linktitle: "Weave Add-On"
+linktitle: "Weave"
 weight: 58
 title: "Weave Add-On"
 addOn: "weave"

--- a/src/markdown-pages/create-installer/single-node-optimized.md
+++ b/src/markdown-pages/create-installer/single-node-optimized.md
@@ -2,8 +2,9 @@
 path: "/docs/create-installer/single-node-optimized"
 date: "2022-02-18"
 weight: 21
-linktitle: "Single-Node Optimized (Beta)"
-title: "Single-Node Optimized (Beta)"
+linktitle: "Single-Node Optimized"
+title: "Single-Node Optimized"
+isBeta: true
 ---
 
 While kURL is flexible and capable of supporting a variety of different distributions, there is beta support for an installer specification that is optimized for use with single-node installations that are not intended to scale to multiple nodes. Some use cases only require a single node, and this installer specification is optimized for these use cases.


### PR DESCRIPTION
This PR adds a red beta tag next to any add-on in beta, both on the Kurl.sh home page, and on the add-ons page in the docs. This PR also removes the redundant "Add-on" from each add-on's link title in the sidebar, and fixes the side bar so that it says "Add-Ons" and not "Add Ons".

[Loom](https://www.loom.com/share/373b16f997b44dc48d5a5efc8713c0b7)