### PR TITLE
fix the bundle urls

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -1,5 +1,5 @@
 KURL_INSTALLER_URL="https://staging.kurl.sh/installer"
-KURL_BUNDLE_URL="https://staging.kurl.sh/bundle"
+KURL_BUNDLE_URL="https://k8s.staging.kurl.sh/bundle"
 API_URL="https://localhost:8072"
 CLUSTER_API_URL="cluster.kurl.sh"
 KURL_URL="https://localhost:8072"

--- a/.env.production
+++ b/.env.production
@@ -1,5 +1,5 @@
 KURL_INSTALLER_URL="https://kurl.sh/installer"
-KURL_BUNDLE_URL="https://kurl.sh/bundle"
+KURL_BUNDLE_URL="https://k8s.kurl.sh/bundle"
 API_URL="https://kurl.sh"
 CLUSTER_API_URL="cluster.kurl.sh"
 KURL_URL="https://k8s.kurl.sh"

--- a/.env.staging
+++ b/.env.staging
@@ -1,5 +1,5 @@
 KURL_INSTALLER_URL="https://staging.kurl.sh/installer"
-KURL_BUNDLE_URL="https://staging.kurl.sh/bundle"
+KURL_BUNDLE_URL="https://k8s.staging.kurl.sh/bundle"
 API_URL="https://staging.kurl.sh"
 CLUSTER_API_URL="cluster.kurl.sh"
 KURL_URL="https://k8s.staging.kurl.sh"


### PR DESCRIPTION
SC-50523

Fix the download bundle URLs. Tested this on Dev environment.

TODO: Test this on staging after merging.