### PR TITLE
Release kURL.sh Docs: Update kURL system-requirements for Collectd on Ubuntu 22.04

### DIFF
--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -10,7 +10,7 @@ title: "System Requirements"
 
 * Ubuntu 18.04
 * Ubuntu 20.04 (Docker version >= 19.03.10)
-* Ubuntu 22.04 (Requires Containerd version >= 1.5.10. Docker containers and Collectd monitoring are not supported.)
+* Ubuntu 22.04 (Requires Containerd version >= 1.5.10. Docker and Collectd add-ons are not supported.)
 * CentOS 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1<sup>\*</sup>, 8.2<sup>\*</sup>, 8.3<sup>\*</sup>, 8.4<sup>\*</sup> (CentOS 8.x requires Containerd)
 * RHEL 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (RHEL 8.x requires Containerd)
 * Oracle Linux 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (OL 8.x requires Containerd)

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -10,7 +10,7 @@ title: "System Requirements"
 
 * Ubuntu 18.04
 * Ubuntu 20.04 (Docker version >= 19.03.10)
-* Ubuntu 22.04 (requires Containerd version >= 1.5.10, no Docker versions are supported)
+* Ubuntu 22.04 (requires Containerd version >= 1.5.10, no Docker/Collectd versions are supported)
 * CentOS 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1<sup>\*</sup>, 8.2<sup>\*</sup>, 8.3<sup>\*</sup>, 8.4<sup>\*</sup> (CentOS 8.x requires Containerd)
 * RHEL 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (RHEL 8.x requires Containerd)
 * Oracle Linux 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (OL 8.x requires Containerd)

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -10,7 +10,7 @@ title: "System Requirements"
 
 * Ubuntu 18.04
 * Ubuntu 20.04 (Docker version >= 19.03.10)
-* Ubuntu 22.04 (requires Containerd version >= 1.5.10, no Docker/Collectd versions are supported)
+* Ubuntu 22.04 (Requires Containerd version >= 1.5.10. Docker containers and Collectd monitoring are not supported.)
 * CentOS 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1<sup>\*</sup>, 8.2<sup>\*</sup>, 8.3<sup>\*</sup>, 8.4<sup>\*</sup> (CentOS 8.x requires Containerd)
 * RHEL 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (RHEL 8.x requires Containerd)
 * Oracle Linux 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6 (OL 8.x requires Containerd)


### PR DESCRIPTION
For release [v2022.08.11-0](https://github.com/replicatedhq/replicated-docs/pull/523)