### PR TITLE
Release Updates to CIS Compliance Page

### DIFF
--- a/src/markdown-pages/install-with-kurl/cis-compliance.md
+++ b/src/markdown-pages/install-with-kurl/cis-compliance.md
@@ -66,10 +66,11 @@ spec:
 * Kubelet no longer attempts to change kernel parameters at runtime. Using kernel parameters other than those expected by Kubernetes can block kubelet from initializing and causes the installation to fail.
 * This feature has been tested with kURL upgrades, however we strongly recommend testing this with your development environments prior to upgrading production.
 * The following failure was identified in kURL testing with `kube-bench` v0.6.8 and is believed to be due to the etcd user not being listed in /etc/passwd mounted from the host:
-```bash
-[FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
-```
- For more information about the etcd data directory ownership check failure issue, see [this issue in GitHub](https://github.com/aquasecurity/kube-bench/issues/1221).
+    ```bash
+    [FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
+    ```
+    * **Note:** This check only fails when `kube-bench` is deployed as a Kubernetes job running on a control plane node.
+    * For more information about the etcd data directory ownership check failure issue, see [this issue in GitHub](https://github.com/aquasecurity/kube-bench/issues/1221).
 
 ## AWS Amazon Linux 2 (AL2) Considerations
 The kernel defaults of this Amazon Machine Image (AMI) are not set properly for CIS compliance. CIS compliance does not allow Kubernetes to change kernel settings itself. You must change the kernel defaults to the following settings before installing with kURL:


### PR DESCRIPTION
Update clarifies known kube-bench failure.

Ref: [sc-54980]