### PR TITLE
feat: show installer object lint error

### DIFF
--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -852,7 +852,11 @@ class Kurlsh extends React.Component {
         this.setState({ installerSha });
       } else {
         const body = await response.json();
-        this.setState({ installerErrMsg: body.error.message || "something went wrong" });
+        if (Array.isArray(body)) {
+          this.setState({ installerErrMsg: body[0].message || "something went wrong" });
+        } else {
+          this.setState({ installerErrMsg: body.error.message || "something went wrong" });
+        }
       }
     } catch (err) {
       this.setState({ installerErrMsg: `${err}` });


### PR DESCRIPTION
this commit slightly changes the interface to show errors returned by the linter. only the first error is presented on the screen, future work will be made to show all returned errors.