### PR TITLE
59979-kurl: Removed KOTS info from TLS Certs and updated links in EKCO add-on

### DIFF
--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -112,7 +112,7 @@ The duration can be adjusted by changing the `ekco.envoyPodsNotReadyDuration` pr
 
 ### TLS Certificate Rotation
 
-EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/add-ons/kotsadm). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
+EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about automatic certificate rotation for the KOTS add-on, which is used by the Replicated app manager, see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
 
 ### Internal Load Balancer
 

--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -112,7 +112,7 @@ The duration can be adjusted by changing the `ekco.envoyPodsNotReadyDuration` pr
 
 ### TLS Certificate Rotation
 
-EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/install-with-kurl/setup-tls-certs#kots-tls-certificate-renewal). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on KOTS), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
+EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/add-ons/kotsadm). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on KOTS), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
 
 ### Internal Load Balancer
 

--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -112,7 +112,7 @@ The duration can be adjusted by changing the `ekco.envoyPodsNotReadyDuration` pr
 
 ### TLS Certificate Rotation
 
-EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the [KOTS add-on](/docs/install-with-kurl/setup-tls-certs#kots-tls-certificate-renewal) since version 0.7.0.
+EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/install-with-kurl/setup-tls-certs#kots-tls-certificate-renewal). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on KOTS), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
 
 ### Internal Load Balancer
 

--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -112,7 +112,7 @@ The duration can be adjusted by changing the `ekco.envoyPodsNotReadyDuration` pr
 
 ### TLS Certificate Rotation
 
-EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/add-ons/kotsadm). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on KOTS), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
+EKCO supports automatic certificate rotation for the [registry add-on](/docs/install-with-kurl/setup-tls-certs#registry) and the [Kubernetes control plane](/docs/install-with-kurl/setup-tls-certs#kubernetes-control-plane) since version 0.5.0 and for the KOTS add-on since version 0.7.0. For more information about the KOTS add-on, see [KOTS add-on](/docs/add-ons/kotsadm). For more information about automatic certificate rotation in Replicated app manager (which uses the KOTS add-on), see [Using TLS Certificates](https://docs.replicated.com/vendor/packaging-using-tls-certs) in the Replicated documentation.
 
 ### Internal Load Balancer
 

--- a/src/markdown-pages/install-with-kurl/setup-tls-certs.md
+++ b/src/markdown-pages/install-with-kurl/setup-tls-certs.md
@@ -6,50 +6,6 @@ linktitle: "TLS Certificates"
 title: "Setting up TLS Certificates"
 ---
 
-After kURL install has completed, you'll be prompted to set up the KOTS Admin Console by directing your browser to `http://<ip>:8800`.   Only after initial install you'll be presented a warning page:
-<br><br><br>
-![tls-certs-insecure](/tls-certs-insecure.png)
-
-
-The next page allows you to configure your TLS certificates:
-<br><br><br>
-![tls-certs-setup](/tls-certs-setup.png)
-
-To continue with the preinstalled self-signed TLS certificates, click "skip & continue".  Otherwise upload your signed TLS certificates as describe on this page.  The hostname is an optional field, and when its specified, its used to redirect your browser to the specified host. 
-
-Once you complete this process then you'll no longer be presented this page when logging into the KOTS Admin Console.  If you direct your browser to `http://<ip>:8800` you'll always be redirected to `https://<ip>:8800`.  
-    
-## KOTS TLS Secret
-
-kURL will set up a Kubernetes secret called `kotsadm-tls`.  The secret stores the TLS certificate, key, and hostname.  Initially the secret will have an annotation set called `acceptAnonymousUploads`.  This indicates that a new TLS certificate can be uploaded as described above.  
-
-## Uploading new TLS Certs
-
-If you've already gone through the setup process once, and you want to upload new TLS certificates, you must run this command to restore the ability to upload new TLS certificates:
-
-`kubectl -n default annotate secret kotsadm-tls acceptAnonymousUploads=1 --overwrite`
-
-<span style="color:red">**Warning: adding this annotation will temporarily create a vulnerability for an attacker to maliciously upload TLS certificates.  Once TLS certificates have been uploaded then the vulnerability is closed again.**</span>
-
-After adding the annotation, you will need to restart the kurl proxy server.  The simplest way is to delete the kurl-proxy pod (the pod will automatically get restarted): 
-
-`kubectl delete pods PROXY_SERVER`
-
-The following command should provide the name of the kurl-proxy server:
-
-`kubectl get pods -A | grep kurl-proxy | awk '{print $2}'`
-
-After the pod has been restarted direct your browser to `http://<ip>:8800/tls` and run through the upload process as described above.  
-    
-It's best to complete this process as soon as possible to avoid anyone from nefariously uploading TLS certificates.  After this process has completed, the vulnerability will be closed, and uploading new TLS certificates will be disallowed again.  In order to upload new TLS certificates you must repeat the steps above. 
-<br><br><br>
-
-### KOTS TLS Certificate Renewal
-
-The certificate used to serve the KOTS Admin Console will be renewed automatically at thirty days prior to expiration if the [EKCO add-on](/docs/add-ons/ekco) is enabled with version 0.7.0+.
-Only the default self-signed certificate will be renewed.
-If a custom certificate has been uploaded then no renewal will be attempted, even if the certificate is expired.
-
 ## Registry
 
 The TLS certificate for the [registry add-on](/docs/add-ons/registry) will be renewed automatically at thirty days prior to expiration if the [EKCO add-on](/docs/add-ons/ekco) is enabled with version 0.5.0+.


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/59979/remove-the-kots-specific-tls-certs-content-from-kurl-sh

After migrating the KOTS-only TLS cert info to [docs.replicated.com](https://deploy-preview-716--replicated-docs.netlify.app/vendor/packaging-using-tls-certs), the information has now been removed from kurl.sh with this PR.

I've also updated the links under the EKCO add-on section.