### PR TITLE
Document Rook to OpenEBS Data Migration is Now Supported

### DIFF
--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -6,8 +6,9 @@ linktitle: "Migrating CSI"
 title: "Migrating to Change kURL CSI Add-Ons"
 ---
 
-As of kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0), MinIO, Longhorn and OpenEBS support migrating data from Rook.
-If you need to migrate to a different storage provider than the aforementioned ones, check out [Migrating](/docs/install-with-kurl/migrating)
+For kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0) and later, MinIO, Longhorn, and OpenEBS support migrating data from Rook.
+
+For information about how to migrate from Rook to a storage provider other than MinIO, Longhorn, or OpenEBS, see [Migrating](/docs/install-with-kurl/migrating).
 
 When initially installing the following kURL spec:
 
@@ -66,7 +67,9 @@ spec:
     isLocalPVEnabled: true
 ```
 
-All PVCs created using Rook will be recreated (with the same name and contents) on Longhorn and OpenEBS, all data within the Rook object store will be copied to MinIO, and Rook will be uninstalled from the cluster.
-Moreover, if migrating Rook from a Kubernetes cluster that is highly available (more than two
-nodes), OpenEBS will attempt to create local volumes on the same nodes where the original Rook PVCs
-were referenced from.
+kURL does the following when you use the specs above to migrate data from Rook:
+
+* Recreates all PVCs that were originally created using Rook onto Longhorn and OpenEBS with the same name and contents. 
+* Copies all data within the Rook object store to MinIO. 
+* Uninstalls Rook from the cluster.
+* If you are migrating off Rook from a Kubernetes cluster that has more than two nodes, OpenEBS attempts to create local volumes on the same nodes where the original Rook PVCs were referenced.

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -6,9 +6,9 @@ linktitle: "Migrating CSI"
 title: "Migrating to Change kURL CSI Add-Ons"
 ---
 
-For kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0) and later, MinIO, Longhorn, and OpenEBS support migrating data from Rook.
+For kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0) and later, there is a suported data migration path from the Rook CSI add-on to either OpenEBS with Local PV, or Longhorn and MinIO as the new storage provider. 
 
-For information about how to migrate from Rook to a storage provider other than MinIO, Longhorn, or OpenEBS, see [Migrating](/docs/install-with-kurl/migrating).
+For information about how to migrate from Rook to a storage provider other than OpenEBS or Longhorn/MinIO, see [Migrating](/docs/install-with-kurl/migrating).
 
 When initially installing the following kURL spec:
 
@@ -28,7 +28,26 @@ spec:
     version: 1.0.4
 ```
 
-You can then migrate _from_ Rook _to_ Minio and/or Longhorn using the following kURL spec:
+You can then automatically migrate data _from_ Rook _to_ OpenEBS with Local PV using the following kURL spec. This requires OpenEBS 3.3.0 or newer. 
+
+```
+apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: new
+spec:
+  kubernetes:
+    version: 1.19.12
+  docker:
+    version: 20.10.5
+  weave:
+    version: 2.6.5
+  openebs:
+    version: 3.3.0
+    isLocalPVEnabled: true
+```
+
+_Or_, you can then migrate data _from_ Rook _to_ Minio and Longhorn using the following kURL spec:
 
 ```
 apiVersion: cluster.kurl.sh/v1beta1
@@ -48,28 +67,9 @@ spec:
     version: 2020-01-25T02-50-51Z
 ```
 
-OpenEBS 3.3.0 and later automatically migrates data from Rook:
-
-```
-apiVersion: cluster.kurl.sh/v1beta1
-kind: Installer
-metadata:
-  name: new
-spec:
-  kubernetes:
-    version: 1.19.12
-  docker:
-    version: 20.10.5
-  weave:
-    version: 2.6.5
-  openebs:
-    version: 3.3.0
-    isLocalPVEnabled: true
-```
-
 kURL does the following when you use the specs above to migrate data from Rook:
 
-* Recreates all PVCs that were originally created using Rook onto Longhorn and OpenEBS with the same name and contents. 
-* Copies all data within the Rook object store to MinIO. 
+* Recreates all PVCs that were originally created using Rook onto OpenEBS or Longhorn with the same name and contents. 
+* Copies all data within the Rook object store to MinIO, if using MinIO. 
+* If you are migrating off of Rook from a Kubernetes cluster that has more than two nodes, OpenEBS attempts to create local volumes on the same nodes where the original Rook PVCs were referenced.
 * Uninstalls Rook from the cluster.
-* If you are migrating off Rook from a Kubernetes cluster that has more than two nodes, OpenEBS attempts to create local volumes on the same nodes where the original Rook PVCs were referenced.

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -6,7 +6,7 @@ linktitle: "Migrating CSI"
 title: "Migrating to Change kURL CSI Add-Ons"
 ---
 
-For kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0) and later, there is a suported data migration path from the Rook CSI add-on to either OpenEBS with Local PV, or Longhorn and MinIO as the new storage provider. 
+For kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0) and later, there is a supported data migration path from the Rook CSI add-on to either OpenEBS with Local PV, or Longhorn and MinIO as the new storage provider. 
 
 For information about how to migrate from Rook to a storage provider other than OpenEBS or Longhorn/MinIO, see [Migrating](/docs/install-with-kurl/migrating).
 

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -6,8 +6,8 @@ linktitle: "Migrating CSI"
 title: "Migrating to Change kURL CSI Add-Ons"
 ---
 
-As of kURL [v2021.07.30-0](https://kurl.sh/release-notes/v2021.07.30-0), MinIO and Longhorn support migrating data from Rook.
-If you need to migrate to a different storage provider than Longhorn, check out [Migrating](/docs/install-with-kurl/migrating)
+As of kURL [v2022.10.28-0](https://kurl.sh/release-notes/v2022.10.28-0), MinIO, Longhorn and OpenEBS support migrating data from Rook.
+If you need to migrate to a different storage provider than the aforementioned ones, check out [Migrating](/docs/install-with-kurl/migrating)
 
 When initially installing the following kURL spec:
 
@@ -27,7 +27,7 @@ spec:
     version: 1.0.4
 ```
 
-and then upgrading to:
+You can then migrate _from_ Rook _to_ Minio and/or Longhorn using the following kURL spec:
 
 ```
 apiVersion: cluster.kurl.sh/v1beta1
@@ -47,4 +47,26 @@ spec:
     version: 2020-01-25T02-50-51Z
 ```
 
-All PVCs created using Rook will be recreated (with the same name and contents) on Longhorn, all data within the Rook object store will be copied to MinIO, and Rook will be uninstalled from the cluster.
+OpenEBS 3.3.0 and later automatically migrates data from Rook:
+
+```
+apiVersion: cluster.kurl.sh/v1beta1
+kind: Installer
+metadata:
+  name: new
+spec:
+  kubernetes:
+    version: 1.19.12
+  docker:
+    version: 20.10.5
+  weave:
+    version: 2.6.5
+  openebs:
+    version: 3.3.0
+    isLocalPVEnabled: true
+```
+
+All PVCs created using Rook will be recreated (with the same name and contents) on Longhorn and OpenEBS, all data within the Rook object store will be copied to MinIO, and Rook will be uninstalled from the cluster.
+Moreover, if migrating Rook from a Kubernetes cluster that is highly available (more than two
+nodes), OpenEBS will attempt to create local volumes on the same nodes where the original Rook PVCs
+were referenced from.

--- a/src/markdown-pages/install-with-kurl/migrating.md
+++ b/src/markdown-pages/install-with-kurl/migrating.md
@@ -7,7 +7,7 @@ title: "Migrating to Change kURL Add-Ons"
 ---
 
 Changing the CRI, CSI, or CNI provider on a kURL install is possible by migrating a [KOTS](https://kots.io/) application to a new cluster.
-If you are only changing the CSI from Rook to Longhorn, check out [Migrating CSI](/docs/install-with-kurl/migrating-csi).
+If you are only changing the CSI from Rook to Longhorn or OpenEBS then check out [Migrating CSI](/docs/install-with-kurl/migrating-csi).
 
 ## Requirements
 

--- a/src/markdown-pages/install-with-kurl/migrating.md
+++ b/src/markdown-pages/install-with-kurl/migrating.md
@@ -7,7 +7,8 @@ title: "Migrating to Change kURL Add-Ons"
 ---
 
 Changing the CRI, CSI, or CNI provider on a kURL install is possible by migrating a [KOTS](https://kots.io/) application to a new cluster.
-If you are only changing the CSI from Rook to Longhorn or OpenEBS then check out [Migrating CSI](/docs/install-with-kurl/migrating-csi).
+
+For information about how to change the CSI from Rook to Longhorn or OpenEBS, see [Migrating CSI](/docs/install-with-kurl/migrating-csi).
 
 ## Requirements
 


### PR DESCRIPTION
OpenEBS `3.3.0` and later now supports an auto migrate feature where it transfers data from Rook based PVCs and moves it to OpenEBS local volume PVCs.