### PR TITLE
feat: enable new linter on kurl.sh

### DIFF
--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -841,7 +841,8 @@ class Kurlsh extends React.Component {
 
   postToKurlInstaller = async (yaml) => {
     this.setState({ installerErrMsg: "" })
-    const url = `${process.env.KURL_INSTALLER_URL}`
+    let url = new URL(`${process.env.KURL_INSTALLER_URL}`);
+    url.searchParams.append("austere", "true");
     try {
       const response = await fetch(url, {
         method: "POST",


### PR DESCRIPTION
this commits enables the new linter in the kurl.sh page by adding a search param called "austere" and setting it to "true".