### PR TITLE
chore: adding documetation node on rook required port

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -246,6 +246,10 @@ cat install.sh | sudo bash -s airgap
                     <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal">
                       UDP port 6081 open between cluster nodes
                     </li>}
+                    {installerData && installerData.spec.rook && installerData.spec.rook.version &&
+                    <li className="u-fontSize--small u-color--dustyGray u-fontWeight--medium u-lineHeight--normal">
+                      TCP port 9090 open between cluster nodes
+                    </li>}
                   </div>
                 </div>
               </div>

--- a/src/markdown-pages/add-ons/rook.md
+++ b/src/markdown-pages/add-ons/rook.md
@@ -91,6 +91,14 @@ spec:
   storageClassName: rook-cephfs
 ```
 
+## System Requirements
+
+The following additional ports must be open between nodes for multi-node clusters:
+
+| Protocol | Direction | Port Range | Purpose                 | Used By |
+| -------  | --------- | ---------- | ----------------------- | ------- |
+| TCP      | Inbound   | 9090       | CSI RBD Plugin Metrics  | All     |
+
 ## Upgrades
 
 It is not possible to upgrade multiple minor versions of the Rook add-on at once.

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -61,23 +61,25 @@ The following ports must be open between nodes for multi-node clusters:
 
 #### Primary Nodes:
 
-| Protocol | Direction | Port Range | Purpose                 | Used By |
-| -------  | --------- | ---------- | ----------------------- | ------- |
-| TCP      | Inbound   | 6443       | Kubernetes API server   | All     |
-| TCP      | Inbound   | 2379-2380  | etcd server client API  | Primary |
-| TCP      | Inbound   | 10250      | kubelet API             | Primary |
-| UDP      | Inbound   | 8472       | Flannel VXLAN           | All     |
-| TCP      | Inbound   | 6783       | Weave Net control       | All     |
-| UDP      | Inbound   | 6783-6784  | Weave Net data          | All     |
+| Protocol | Direction | Port Range | Purpose                      | Used By |
+| -------  | --------- | ---------- | ---------------------------- | ------- |
+| TCP      | Inbound   | 6443       | Kubernetes API server        | All     |
+| TCP      | Inbound   | 2379-2380  | etcd server client API       | Primary |
+| TCP      | Inbound   | 10250      | kubelet API                  | Primary |
+| UDP      | Inbound   | 8472       | Flannel VXLAN                | All     |
+| TCP      | Inbound   | 6783       | Weave Net control            | All     |
+| UDP      | Inbound   | 6783-6784  | Weave Net data               | All     |
+| TCP      | Inbound   | 9090       | Rook CSI RBD Plugin Metrics  | All     |
 
 #### Secondary Nodes:
 
-| Protocol | Direction | Port Range | Purpose                 | Used By |
-| -------  | --------- | ---------- | ----------------------- | ------- |
-| TCP      | Inbound   | 10250      | kubelet API             | Primary |
-| UDP      | Inbound   | 8472       | Flannel VXLAN           | All     |
-| TCP      | Inbound   | 6783       | Weave Net control       | All     |
-| UDP      | Inbound   | 6783-6784  | Weave Net data          | All     |
+| Protocol | Direction | Port Range | Purpose                      | Used By |
+| -------  | --------- | ---------- | ---------------------------- | ------- |
+| TCP      | Inbound   | 10250      | kubelet API                  | Primary |
+| UDP      | Inbound   | 8472       | Flannel VXLAN                | All     |
+| TCP      | Inbound   | 6783       | Weave Net control            | All     |
+| UDP      | Inbound   | 6783-6784  | Weave Net data               | All     |
+| TCP      | Inbound   | 9090       | Rook CSI RBD Plugin Metrics  | All     |
 
 These ports are required for [Kubernetes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#control-plane-node-s) and [Weave Net](https://www.weave.works/docs/net/latest/faq/#ports).
 
@@ -95,7 +97,6 @@ In addition to the ports listed above that must be open between nodes, the follo
 | 9100 | [prometheus](/docs/add-ons/prometheus) node-exporter metrics server |
 | 10257 | kube-controller-manager health server |
 | 10259 | kube-scheduler health server |
-| 9090 | [rook-ceph](/docs/add-ons/rook) CSI driver (if rook add-on is installed) |
 
 
 ## High Availability Requirements


### PR DESCRIPTION
this pr adds a documentation note informing about the necessity of leaving port 9090/tcp available in the nodes before installing the rook add-on