### PR TITLE
62269: Add directory disk space requirements table

### DIFF
--- a/src/markdown-pages/add-ons/docker.md
+++ b/src/markdown-pages/add-ons/docker.md
@@ -10,7 +10,9 @@ Docker is a CRI (Container Runtime Interface).
 If Docker is not used, an alternative CRI must be used in its place.
 See [containerd documentation](/docs/add-ons/containerd) for more information.
 
-Kubenetes 1.24.0+ does not support Dockershim, therefore you must use an alternative CRI, such as [containerd](/docs/add-ons/containerd), instead. 
+Kubenetes 1.24.0+ does not support Dockershim, therefore you must use an alternative CRI, such as [containerd](/docs/add-ons/containerd), instead.
+
+For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements).
 
 ## Advanced Install Options
 

--- a/src/markdown-pages/add-ons/kurl.md
+++ b/src/markdown-pages/add-ons/kurl.md
@@ -6,7 +6,7 @@ weight: 45
 title: "Kurl Add-On"
 addOn: "kurl"
 ---
-
+For disk space requirements, see [Core Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements#core-directory-disk-space-requirements).
 
 ## Advanced Install Options
 

--- a/src/markdown-pages/add-ons/longhorn.md
+++ b/src/markdown-pages/add-ons/longhorn.md
@@ -9,8 +9,8 @@ addOn: "longhorn"
 
 [Longhorn](https://longhorn.io/) is a CNCF Sandbox Project originally developed by Rancher labs as a “lightweight, reliable and easy-to-use distributed block storage system for Kubernetes”. Longhorn uses a microservice-based architecture to create a pod for every Custom Resource in the Longhorn ecosystem: Volumes, Replicas, a control plane, a data plane, etc.
 
-Longhorn uses the `/var/lib/longhorn` directory for storage on all nodes.
-This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster.
+Longhorn uses the `/var/lib/longhorn` directory for storage on all nodes. For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements).
+
 For production installs, an SSD should be mounted at `/var/lib/longhorn`.
 
 ## Advanced Install Options

--- a/src/markdown-pages/add-ons/rook.md
+++ b/src/markdown-pages/add-ons/rook.md
@@ -31,7 +31,7 @@ flags-table
 ## Block Storage
 
 For Rook versions 1.4.3 and later, block storage is required.
-For Rook versions earlier than 1.4.3, block storage is recommended in production clusters.
+For Rook versions earlier than 1.4.3, block storage is recommended in production clusters. For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements).
 
 You can enable and disable block storage for Rook versions earlier than 1.4.3 with the `isBlockStorageEnabled` field in the kURL spec.
 
@@ -65,7 +65,8 @@ For more information, see [Block Storage](#block-storage) above.
 When using the filesystem for storage, each node in the cluster has a single OSD backed by a directory in `/opt/replicated/rook`.
 Nodes with a Ceph Monitor also use `/var/lib/rook`.
 
-At minimum, 10GB of disk space must be available to `/var/lib/rook` for the Ceph Monitors and other configs.
+Sufficient disk space must be available to `/var/lib/rook` for the Ceph Monitors and other configs. For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements). 
+
 We recommend a separate partition to prevent a disruption in Ceph's operation as a result of `/var` or the root partition running out of space.
 
 **Note**: All disks used for storage in the cluster should be of similar size.

--- a/src/markdown-pages/install-with-kurl/host-preflights.md
+++ b/src/markdown-pages/install-with-kurl/host-preflights.md
@@ -39,8 +39,7 @@ The following checks run on all nodes during installations and upgrades:
 * Firewalld is disabled.
 * SELinux is disabled.
 * At least one nameserver is accessible on a non-loopback address.
-* Minimum disk space for the /var/lib/kubelet directory. For information about disk space requirements, see [Core Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements#core-directory-disk-space-requirements).
- (Warns when less than 10GiB available or when it is more than 60% full.)
+* Minimum disk space for the /var/lib/kubelet directory. (Warns when less than 10GiB available or when it is more than 60% full.) For information about disk space requirements, see [Core Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements#core-directory-disk-space-requirements).
 * The system clock is synchronized and the time zone is set to UTC.
 
 #### Installations Only

--- a/src/markdown-pages/install-with-kurl/host-preflights.md
+++ b/src/markdown-pages/install-with-kurl/host-preflights.md
@@ -12,12 +12,12 @@ These checks can also run conditionally, depending on whether the installer is p
 
 The installer has default host preflight checks that run to ensure that certain conditions are met (such as supported operating systems, disk usage, and so on).
 The default host preflight checks are designed and maintained to help ensure the successful installation and ongoing health of the cluster.
-The default preflight checks are also customizable. New host preflight checks can be added to run in addition to the defaults, or the default checks can be disabled to allow for a new set of host preflight checks to run instead. 
+The default preflight checks are also customizable. New host preflight checks can be added to run in addition to the defaults, or the default checks can be disabled to allow for a new set of host preflight checks to run instead.
 For more information, see [customizing host preflight checks](/docs/create-installer/host-preflights).
 
-Host prelight failures block the installation from continuing and exit with a non-zero return code. 
+Host prelight failures block the installation from continuing and exit with a non-zero return code.
 This behavior can be changed as follows:
-* Failures can be bypassed with the [`host-preflight-ignore` flag](/docs/install-with-kurl/advanced-options). 
+* Failures can be bypassed with the [`host-preflight-ignore` flag](/docs/install-with-kurl/advanced-options).
 * For a more conservative approach, the [`host-preflight-enforce-warnings` flag](/docs/install-with-kurl/advanced-options) can be used to block the installation on warnings.
 * The [`exclude-builtin-host-preflights` flag](/docs/install-with-kurl/advanced-options) can be used to skip the default host preflight checks and run only the custom checks.
 
@@ -39,7 +39,8 @@ The following checks run on all nodes during installations and upgrades:
 * Firewalld is disabled.
 * SELinux is disabled.
 * At least one nameserver is accessible on a non-loopback address.
-* /var/lib/kubelet has at least 30GiB total space and is less than 80% full. (Warns when less than 10GiB available or when it is more than 60% full.)
+* Minimum disk space for the /var/lib/kubelet directory. For information about disk space requirements, see [Core Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements#core-directory-disk-space-requirements).
+ (Warns when less than 10GiB available or when it is more than 60% full.)
 * The system clock is synchronized and the time zone is set to UTC.
 
 #### Installations Only

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -46,8 +46,7 @@ The following table lists the add-on directory locations and disk space requirem
 |     Name      |      Location        |          Requirements          |
 | --------------| -------------------  | ------------------------------|
 | Containerd    | /var/lib/containerd/ | N/A                           |       
-| Docker        | /var/lib/docker/     |  30 GB and less than 80% full |
-| Dockershim    | /var/lib/dockershim/ | N/A                           |
+| Docker        | <p>/var/lib/docker/</p><p>/var/lib/dockershim/</p> | <p>Docker: 30 GB and less than 80% full</p><p>Dockershim: N/A</p><p>See [Docker Add-on](/docs/add-ons/docker). |
 | Longhorn      | /var/lib/longhorn/   | <p>This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn).</p><p>For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights).</p> |
 | OpenEBS       | /var/openebs/        |  N/A                          |
 | Rook          | <p>Versions earlier than 1.0.4-x: /opt/replicated/rook</p><p>Versions 1.0.4-x and later: /var/lib/rook/</p> | <p>/opt/replicated/rook requires a minimum of 10GB and less than 80% full.</p><p>/var/lib/rook/ requires a 10 GB block device.</p><p>See [Rook Add-on](/docs/add-ons/rook).</p> |

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -36,12 +36,12 @@ The following table lists information about the core directory requirements.
 | Name        |      Location        |                    Requirements                    |
 | ------------| -------------------  | -------------------------------------------------- |
 | etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
-| kURL        | /var/lib/kurl/       | <p>5 GB</p><p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
+| kURL        | /var/lib/kurl/       | <p>5 GB</p><p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images.</p><p>This directory must be writeable by the kURL installer and must have sufficient disk space.</p><p>This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
 | kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 
 ## Add-on Directory Disk Space Requirements
 
-The following table lists the add-on directory locations and disk space requirements, if applicable. For additional requirements, see the specific topic for the add-on.
+The following table lists the add-on directory locations and disk space requirements, if applicable. For any additional requirements, see the specific topic for the add-on.
 
 |     Name      |      Location        |          Requirements          |
 | --------------| -------------------  | ------------------------------|
@@ -50,7 +50,7 @@ The following table lists the add-on directory locations and disk space requirem
 | Dockershim    | /var/lib/dockershim/ | N/A                           |
 | Longhorn      | /var/lib/longhorn/   | <p>This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn).</p><p>For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights).</p> |
 | OpenEBS       | /var/openebs/        |  N/A                          |
-| Rook          | <p>Versions earlier than 1.0.4-x: /opt/replicated/rook</p><p>Version 1.0.4-x and later: /var/lib/rook/</p> | <p>/opt/replicated/rook requires a minimum of 10GB and less than 80% full.</p><p>/var/lib/rook/ requires a 10 GB block device.</p><p>For more information, see [Rook Add-on](/docs/add-ons/rook).</p> |
+| Rook          | <p>Versions earlier than 1.0.4-x: /opt/replicated/rook</p><p>Versions 1.0.4-x and later: /var/lib/rook/</p> | <p>/opt/replicated/rook requires a minimum of 10GB and less than 80% full.</p><p>/var/lib/rook/ requires a 10 GB block device.</p><p>See [Rook Add-on](/docs/add-ons/rook).</p> |
 |Weave          | <p>/var/lib/cni/</p><p>/var/lib/weave/</p> |  N/A             |
 
 ## Networking Requirements

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -33,22 +33,31 @@ title: "System Requirements"
 
 kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images.
 
-The following table lists information about the kURL directory requirements and other directories used by the kURL installer, depending on the options that you choose.
+### Core Directory Requirements
 
-|      Location        | Minimum Disk Space |                    Description                     |
-| -------------------  | ------------------ | -------------------------------------------------- |
-| /opt/replicated/rook | 10GiB and less than 80% full | See [Host Preflights](/docs/install-with-kurl/host-preflights). |
-| /var/lib/containerd/ |                    | See [Containerd Add-on](/docs/add-ons/containerd). |       
-| /var/lib/cni/        |                    |                                                    |
-| /var/lib/docker/     |  30 GiB and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](/docs/install-with-kurl/host-preflights). |
-| /var/lib/dockershim/ |                    |  Kubernetes 1.24.0+ does not support Dockershim. See [Docker Add-on](/docs/add-ons/docker). |
-| /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
-| /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
-| /var/lib/kubelet/    | 30 GiB and less than 80% full| See [Host Preflights](/docs/install-with-kurl/host-preflights). |
-| /var/lib/longhorn/   |                     | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
-| /var/openebs/        |                     | See [OpenEBS Add-on](/docs/add-ons/openebs). |
-| /var/lib/rook/       | 40 GB               |                                                   |
-| /var/lib/weave/      |                     |                                                   |
+The following table lists information about the core directory requirements.
+
+| Name        |      Location        |                    Requirements                    |
+| ------------| -------------------  | -------------------------------------------------- |
+| etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
+| kURL        | /var/lib/kurl/       | 5 GB minimum. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
+| kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
+
+### Add-on Directory Requirements
+
+The following table lists the add-on directory locations and requirements, if applicable.
+
+|     Name      |      Location        |          Requirements          |
+| --------------| -------------------  | ------------------------------|
+| Containerd    | /var/lib/containerd/ | N/A                           |       
+| Docker        | /var/lib/docker/     |  30 GB and less than 80% full |
+| Dockershim    | /var/lib/dockershim/ | N/A                           |
+| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn).
+
+For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
+| OpenEBS       | /var/openebs/        |  N/A                          |
+| Rook          | Versions earlier than 1.0.4-x and earlier: /opt/replicated/rook, version 1.0.4-x and later: /var/lib/rook/ | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. /var/lib/rook/ requires a 10 GB block device.  |
+|Weave          | /var/lib/cni/ and /var/lib/weave/ |  N/A             |
 
 ## Networking Requirements
 ### Firewall Openings for Online Installations

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -36,21 +36,21 @@ The following table lists information about the core directory requirements.
 | Name        |      Location        |                    Requirements                    |
 | ------------| -------------------  | -------------------------------------------------- |
 | etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
-| kURL        | /var/lib/kurl/       | 5 GB. kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
+| kURL        | /var/lib/kurl/       | 5 GB <p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
 | kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 
 ## Add-on Directory Disk Space Requirements
 
-The following table lists the add-on directory locations and disk space requirements, if applicable.
+The following table lists the add-on directory locations and disk space requirements, if applicable. For additional requirements, see the specific topic for the add-on.
 
 |     Name      |      Location        |          Requirements          |
 | --------------| -------------------  | ------------------------------|
 | Containerd    | /var/lib/containerd/ | N/A                           |       
 | Docker        | /var/lib/docker/     |  30 GB and less than 80% full |
 | Dockershim    | /var/lib/dockershim/ | N/A                           |
-| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
+| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). <p>For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights).</p> |
 | OpenEBS       | /var/openebs/        |  N/A                          |
-| Rook          | Versions earlier than 1.0.4-x and earlier: /opt/replicated/rook, version 1.0.4-x and later: /var/lib/rook/ | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. /var/lib/rook/ requires a 10 GB block device. For more information, see [Rook Add-on](/docs/add-ons/rook). |
+| Rook          | Versions earlier than 1.0.4-x: /opt/replicated/rook. <p>Version 1.0.4-x and later: /var/lib/rook/</p> | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. <p>/var/lib/rook/ requires a 10 GB block device.</p><p>For more information, see [Rook Add-on](/docs/add-ons/rook).</p> |
 |Weave          | /var/lib/cni/ and /var/lib/weave/ |  N/A             |
 
 ## Networking Requirements

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -29,34 +29,28 @@ title: "System Requirements"
     * **Note**: When [Flannel](/docs/add-ons/flannel) is enabled, UDP port 8472 open between cluster nodes
     * **Note**: When [Weave](/docs/add-ons/weave) is enabled, TCP port 6783 and UDP port 6783 and 6784 open between cluster nodes
 
-## Directory Disk Space Requirements
-
-kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images.
-
-### Core Directory Requirements
+## Core Directory Disk Space Requirements
 
 The following table lists information about the core directory requirements.
 
 | Name        |      Location        |                    Requirements                    |
 | ------------| -------------------  | -------------------------------------------------- |
 | etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
-| kURL        | /var/lib/kurl/       | 5 GB minimum. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
+| kURL        | /var/lib/kurl/       | 5 GB. kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
 | kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 
-### Add-on Directory Requirements
+## Add-on Directory Disk Space Requirements
 
-The following table lists the add-on directory locations and requirements, if applicable.
+The following table lists the add-on directory locations and disk space requirements, if applicable.
 
 |     Name      |      Location        |          Requirements          |
 | --------------| -------------------  | ------------------------------|
 | Containerd    | /var/lib/containerd/ | N/A                           |       
 | Docker        | /var/lib/docker/     |  30 GB and less than 80% full |
 | Dockershim    | /var/lib/dockershim/ | N/A                           |
-| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn).
-
-For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
+| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | OpenEBS       | /var/openebs/        |  N/A                          |
-| Rook          | Versions earlier than 1.0.4-x and earlier: /opt/replicated/rook, version 1.0.4-x and later: /var/lib/rook/ | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. /var/lib/rook/ requires a 10 GB block device.  |
+| Rook          | Versions earlier than 1.0.4-x and earlier: /opt/replicated/rook, version 1.0.4-x and later: /var/lib/rook/ | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. /var/lib/rook/ requires a 10 GB block device. For more information, see [Rook Add-on](/docs/add-ons/rook). |
 |Weave          | /var/lib/cni/ and /var/lib/weave/ |  N/A             |
 
 ## Networking Requirements

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -36,7 +36,7 @@ The following table lists information about the core directory requirements.
 | Name        |      Location        |                    Requirements                    |
 | ------------| -------------------  | -------------------------------------------------- |
 | etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
-| kURL        | /var/lib/kurl/       | 5 GB <p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
+| kURL        | /var/lib/kurl/       | <p>5 GB</p><p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
 | kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 
 ## Add-on Directory Disk Space Requirements
@@ -48,10 +48,10 @@ The following table lists the add-on directory locations and disk space requirem
 | Containerd    | /var/lib/containerd/ | N/A                           |       
 | Docker        | /var/lib/docker/     |  30 GB and less than 80% full |
 | Dockershim    | /var/lib/dockershim/ | N/A                           |
-| Longhorn      | /var/lib/longhorn/   | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). <p>For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights).</p> |
+| Longhorn      | /var/lib/longhorn/   | <p>This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn).</p><p>For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights).</p> |
 | OpenEBS       | /var/openebs/        |  N/A                          |
-| Rook          | Versions earlier than 1.0.4-x: /opt/replicated/rook. <p>Version 1.0.4-x and later: /var/lib/rook/</p> | /opt/replicated/rook requires a minimum of 10GB and less than 80% full. <p>/var/lib/rook/ requires a 10 GB block device.</p><p>For more information, see [Rook Add-on](/docs/add-ons/rook).</p> |
-|Weave          | /var/lib/cni/ and /var/lib/weave/ |  N/A             |
+| Rook          | <p>Versions earlier than 1.0.4-x: /opt/replicated/rook</p><p>Version 1.0.4-x and later: /var/lib/rook/</p> | <p>/opt/replicated/rook requires a minimum of 10GB and less than 80% full.</p><p>/var/lib/rook/ requires a 10 GB block device.</p><p>For more information, see [Rook Add-on](/docs/add-ons/rook).</p> |
+|Weave          | <p>/var/lib/cni/</p><p>/var/lib/weave/</p> |  N/A             |
 
 ## Networking Requirements
 ### Firewall Openings for Online Installations

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -40,7 +40,7 @@ The following table lists information about the kURL directory requirements and 
 | /opt/replicated/rook | 10GiB and less than 80% full | See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | /var/lib/containerd/ |                    | See [Containerd Add-on](/docs/add-ons/containerd). |       
 | /var/lib/cni/        |                    |                                                    |
-| /var/lib/docker/     |  30 GiB total space and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](/docs/install-with-kurl/host-preflights). |
+| /var/lib/docker/     |  30 GiB and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | /var/lib/dockershim/ |                    |  Kubernetes 1.24.0+ does not support Dockershim. See [Docker Add-on](/docs/add-ons/docker). |
 | /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
 | /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -29,13 +29,28 @@ title: "System Requirements"
     * **Note**: When [Flannel](/docs/add-ons/flannel) is enabled, UDP port 8472 open between cluster nodes
     * **Note**: When [Weave](/docs/add-ons/weave) is enabled, TCP port 6783 and UDP port 6783 and 6784 open between cluster nodes
 
-## kURL Dependencies Directory
+## Directory Disk Space Requirements
 
-kURL will install additional dependencies in the directory /var/lib/kurl/.
-These dependencies include utilities as well as system packages and container images.
-This directory must be writeable by the kURL installer and must have sufficient disk space (5 GB).
-This directory can be overridden with the flag `kurl-install-directory`.
-For more information see [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).
+kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images.
+
+The following table lists information about the kURL directory requirements and other directories used by the kURL installer, depending on the options that you choose.
+
+|      Location        | Minimum Disk Space |                    Description                     |
+| -------------------  | ------------------ | -------------------------------------------------- |
+| /opt/replicated/rook | 10GiB and less than 80% full | See [Host Preflights](install-with-kurl/host-preflights) |
+| /var/lib/containerd/ |                    | See [Containerd Add-on](/docs/add-ons/containerd). |       
+| /var/lib/cni/        |                    |                                                    |
+| /var/lib/docker/     |  30 GiB total space and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](install-with-kurl/host-preflights). |
+| /var/lib/dockershim/ |                    |                                                    |
+| /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [CLoud DIsk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
+| /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`.
+See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
+| /var/lib/kubelet/    | 30 GiB and less than 80% full| See [Host Preflights](install-with-kurl/host-preflights). |
+| /var/lib/longhorn/   |                     | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](install-with-kurl/host-preflights). |
+| /var/openebs/        |                     | See [OpenEBS Add-on](/docs/add-ons/openebs). |
+| /var/lib/rook/       | 40 GB               |                                                   |
+| /var/lib/weave/      |                     |                                                   |
+
 ## Networking Requirements
 ### Firewall Openings for Online Installations
 

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -36,7 +36,7 @@ The following table lists information about the core directory requirements.
 | Name        |      Location        |                    Requirements                    |
 | ------------| -------------------  | -------------------------------------------------- |
 | etcd        | /var/lib/etcd/       | This directory has a high I/O requirement. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |
-| kURL        | /var/lib/kurl/       | <p>5 GB</p><p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images.</p><p>This directory must be writeable by the kURL installer and must have sufficient disk space.</p><p>This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
+| kURL        | /var/lib/kurl/       | <p>5 GB</p><p>kURL installs additional dependencies in the directory /var/lib/kurl/, including utilities, system packages, and container images. This directory must be writeable by the kURL installer and must have sufficient disk space.</p><p>This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options).</p> |
 | kubelet     | /var/lib/kubelet/    | 30 GiB and less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 
 ## Add-on Directory Disk Space Requirements

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -37,16 +37,15 @@ The following table lists information about the kURL directory requirements and 
 
 |      Location        | Minimum Disk Space |                    Description                     |
 | -------------------  | ------------------ | -------------------------------------------------- |
-| /opt/replicated/rook | 10GiB and less than 80% full | See [Host Preflights](install-with-kurl/host-preflights) |
+| /opt/replicated/rook | 10GiB and less than 80% full | See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | /var/lib/containerd/ |                    | See [Containerd Add-on](/docs/add-ons/containerd). |       
 | /var/lib/cni/        |                    |                                                    |
-| /var/lib/docker/     |  30 GiB total space and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](install-with-kurl/host-preflights). |
+| /var/lib/docker/     |  30 GiB total space and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | /var/lib/dockershim/ |                    |                                                    |
-| /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [CLoud DIsk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
-| /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`.
-See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
-| /var/lib/kubelet/    | 30 GiB and less than 80% full| See [Host Preflights](install-with-kurl/host-preflights). |
-| /var/lib/longhorn/   |                     | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](install-with-kurl/host-preflights). |
+| /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
+| /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
+| /var/lib/kubelet/    | 30 GiB and less than 80% full| See [Host Preflights](/docs/install-with-kurl/host-preflights). |
+| /var/lib/longhorn/   |                     | This directory should have enough space to hold a complete copy of every PersistentVolumeClaim that will be in the cluster. See [Longhorn Add-on](/docs/add-ons/longhorn). For host preflights, it should have 50GiB total space and be less than 80% full. See [Host Preflights](/docs/install-with-kurl/host-preflights). |
 | /var/openebs/        |                     | See [OpenEBS Add-on](/docs/add-ons/openebs). |
 | /var/lib/rook/       | 40 GB               |                                                   |
 | /var/lib/weave/      |                     |                                                   |

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -41,7 +41,7 @@ The following table lists information about the kURL directory requirements and 
 | /var/lib/containerd/ |                    | See [Containerd Add-on](/docs/add-ons/containerd). |       
 | /var/lib/cni/        |                    |                                                    |
 | /var/lib/docker/     |  30 GiB total space and less than 80% full | See [Docker Add-on](/docs/add-ons/docker) and [Host Preflights](/docs/install-with-kurl/host-preflights). |
-| /var/lib/dockershim/ |                    |                                                    |
+| /var/lib/dockershim/ |                    |  Kubernetes 1.24.0+ does not support Dockershim. See [Docker Add-on](/docs/add-ons/docker). |
 | /var/lib/etcd/       | 8 GB ultra disk    | This minimum applies when using Azure D4ds_v4 with the ultra disk mounted at /var/lib/etcd provisioned with 2400 IOPS and 128 MB/s throughput. See [Cloud Disk Performance](/docs/install-with-kurl/system-requirements#cloud-disk-performance). |                   |                                                    |
 | /var/lib/kurl/       | 5 GB               |  This directory must be writeable by the kURL installer and must have sufficient disk space. This directory can be overridden with the flag `kurl-install-directory`. See [kURL Advanced Install Options](/docs/install-with-kurl/advanced-options). |
 | /var/lib/kubelet/    | 30 GiB and less than 80% full| See [Host Preflights](/docs/install-with-kurl/host-preflights). |


### PR DESCRIPTION
SC: https://app.shortcut.com/replicated/story/62269/longhorn-and-kubelet-requirements-missing

Although this SC story asks only for Longhorn and kubelet, another related story asked for this entire list in this table. 

Previews:

- https://639a23ed8095c5301774e5bb--kurlsh-staging.netlify.app/docs/install-with-kurl/system-requirements#core-directory-disk-space-requirements
- https://639a23ed8095c5301774e5bb--kurlsh-staging.netlify.app/docs/install-with-kurl/system-requirements#add-on-directory-disk-space-requirements
- https://639a23ed8095c5301774e5bb--kurlsh-staging.netlify.app/docs/install-with-kurl/host-preflights#all-nodes
