### PR TITLE
Clarifies disk requirements for Rook add-on

### DIFF
--- a/src/markdown-pages/add-ons/rook.md
+++ b/src/markdown-pages/add-ons/rook.md
@@ -30,8 +30,10 @@ flags-table
 
 ## Block Storage
 
-For Rook versions 1.4.3 and later, block storage is required.
-For Rook versions earlier than 1.4.3, block storage is recommended in production clusters. For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements).
+Rook versions 1.4.3 and later require a dedicated block device attached to each node in the cluster.
+To meet this block storage requirement, you must add an unformatted disk that is used only for Rook to each node.
+For Rook versions earlier than 1.4.3, a dedicated block device is recommended in production clusters.
+For disk requirements, see [Add-on Directory Disk Space Requirements](/docs/install-with-kurl/system-requirements/#add-on-directory-disk-space-requirements).
 
 You can enable and disable block storage for Rook versions earlier than 1.4.3 with the `isBlockStorageEnabled` field in the kURL spec.
 
@@ -53,7 +55,7 @@ In the example above, the `isBlockStorageEnabled` field is set to `true`.
 Additionally, `blockDeviceFilter` instructs Rook to use only block devices that match the specified regex.
 For more information about the available options, see [Advanced Install Options](#advanced-install-options) above.
 
-The Rook add-on waits for a disk before continuing with installation.
+The Rook add-on waits for the dedicated disk that you attached to your node before continuing with installation.
 If you attached a disk to your node, but the installer is waiting at the Rook add-on installation step, see [OSD pods are not created on my devices](https://rook.io/docs/rook/v1.0/ceph-common-issues.html#osd-pods-are-not-created-on-my-devices) in the Rook documentation for troubleshooting information.
 
 ## Filesystem Storage

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -23,7 +23,7 @@ title: "System Requirements"
 * 4 AMD64 CPUs or equivalent per machine
 * 8 GB of RAM per machine
 * 40 GB of Disk Space per machine
-* The Rook add-on version 1.4.3 and later requires block storage on each node in the cluster.
+* The Rook add-on version 1.4.3 and later requires a dedicated block device on each node in the cluster.
   For more information about how to enable block storage for Rook, see [Block Storage](/docs/add-ons/rook#block-storage) in _Rook Add-On_.
 * TCP ports 2379, 2380, 6443, 10250, 10251 and 10252 open between cluster nodes
     * **Note**: When [Flannel](/docs/add-ons/flannel) is enabled, UDP port 8472 open between cluster nodes


### PR DESCRIPTION
Related docs story: https://app.shortcut.com/replicated/story/64069/clarify-the-need-for-an-extra-available-disk-when-installing-rook-1-4-3 requested by @ricardomaraschini 

