### PR TITLE
add serverFlags field to velero add-on

### DIFF
--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -918,38 +918,9 @@ class Kurlsh extends React.Component {
   }
 
   handleOptionChange = (path, currentTarget, type) => {
-    let addOnData = {}
     let elementToFocus;
     const [field, key] = path.split('.');
-
-    if (currentTarget.type === "checkbox") {
-      if (type === "boolean") {
-        addOnData = {
-          inputValue: currentTarget.checked ? true : false,
-          isChecked: currentTarget.checked
-        }
-      } else {
-        if (type === "string") {
-          addOnData = {
-            inputValue: "",
-            isChecked: currentTarget.checked,
-          }
-        } else {
-          addOnData = {
-            inputValue: 0,
-            isChecked: currentTarget.checked,
-          }
-        }
-      }
-    } else if (currentTarget.type === "number") {
-      addOnData = {
-        inputValue: parseInt(currentTarget.value, 10) || 0
-      }
-    } else {
-      addOnData = {
-        inputValue: currentTarget.value
-      }
-    }
+    const addOnData = this.addOnDataFromInput(currentTarget, type);
 
     this.setState({
       advancedOptions: {
@@ -973,6 +944,56 @@ class Kurlsh extends React.Component {
         this.postToKurlInstaller(this.getYaml(this.state.installerSha));
       }
     });
+  }
+
+  addOnDataFromInput(targetInput, fieldType) {
+    let addOnData = {}
+
+    if (targetInput.type === "checkbox") {
+      if (fieldType === "boolean") {
+        addOnData = {
+          inputValue: targetInput.checked ? true : false,
+          isChecked: targetInput.checked
+        }
+      } else {
+        if (fieldType === "string") {
+          addOnData = {
+            inputValue: "",
+            isChecked: targetInput.checked,
+          }
+        } else if (fieldType === "array[string]") {
+          addOnData = {
+            inputValue: [],
+            isChecked: targetInput.checked,
+          }
+        } else {
+          addOnData = {
+            inputValue: 0,
+            isChecked: targetInput.checked,
+          }
+        }
+      }
+    } else if (targetInput.type === "number") {
+      addOnData = {
+        inputValue: parseInt(targetInput.value, 10) || 0
+      }
+    } else if (targetInput.type === "text") {
+      if (fieldType === "array[string]") {
+        addOnData = {
+          inputValue: targetInput.value.split(",")
+        }
+      } else {
+        addOnData = {
+          inputValue: targetInput.value
+        }
+      }
+    } else {
+      addOnData = {
+        inputValue: targetInput.value
+      }
+    }
+
+    return addOnData;
   }
 
   renderMonacoEditor = () => {
@@ -1077,12 +1098,12 @@ class Kurlsh extends React.Component {
                     </ReactTooltip>
                     <span data-tip data-for={`tt_${addOn}_${data.flag}`} className="icon clickable u-questionMarkCircle u-marginLeft--normal u-marginRight--normal"></span>
                   </div>
-                  {option.type === "string" || option.type === "number" ?
+                  {option.type === "string" || option.type === "array[string]" || option.type === "number" ?
                     <div>
                       <input
                         id={`${addOn}_${data.flag}`}
                         className="flex2 addOnOption"
-                        type={option.type === "string" ? "text" : "number"}
+                        type={option.type === "string" || option.type === "array[string]" ? "text" : "number"}
                         onChange={e => this.handleOptionChange(`${addOn}.${data.flag}`, e.currentTarget, option.type)}
                         disabled={!currentOption || (currentOption && !currentOption.isChecked)}
                         value={currentOption ? currentOption.inputValue : ""}

--- a/src/components/__tests__/kurlsh.js
+++ b/src/components/__tests__/kurlsh.js
@@ -206,4 +206,62 @@ describe("Kurl", () => {
       expect(finalVersions).toEqual([{version: "2.8.x"}, {version: "2.8.1-20221025"}, {version: "2.8.1-20221006"}, {version: "2.8.1-20220825"}, {version: "2.8.1-20220720"}, {version: "2.8.1-20220616"}, {version: "2.8.1"}, {version: "2.7.x"}, {version: "2.7.0"}, {version: "2.6.x"}, {version: "latest"}, {version: "2.6.5-20221025"}, {version: "2.6.5-20221006"}, {version: "2.6.5-20220825"}, {version: "2.6.5-20220720"}, {version: "2.6.5-20220616"}, {version: "2.6.5"}, {version: "2.6.4"}, {version: "2.5.x"}, {version: "2.5.2"}, {version: "None"}]);
     });
   });
+
+  describe("addOnDataFromInput", () => {
+    it("handles checkbox input changes for boolean fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "checkbox", checked: true}, "boolean");
+      const expected = {inputValue: true, isChecked: true};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles checkbox input changes for string fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "checkbox", checked: true}, "string");
+      const expected = {inputValue: "", isChecked: true};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles checkbox input changes for number fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "checkbox", checked: true}, "number");
+      const expected = {inputValue: 0, isChecked: true};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles checkbox input changes for array[string] fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "checkbox", checked: true}, "array[string]");
+      const expected = {inputValue: [], isChecked: true};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles number input changes for number fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "number", value: 1}, "number");
+      const expected = {inputValue: 1};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles text input changes for array[string] fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "text", value: "foo,bar"}, "array[string]");
+      const expected = {inputValue: ["foo", "bar"]};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles text input changes for string fields", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "text", value: "foo"}, "string");
+      const expected = {inputValue: "foo"};
+      expect(actual).toEqual(expected);
+    });
+
+    it("handles all other input type changes", () => {
+      const kurlsh = new Kurl(defaultProps);
+      const actual = kurlsh.addOnDataFromInput({type: "foo", value: "bar"}, "baz");
+      const expected = {inputValue: "bar"};
+      expect(actual).toEqual(expected);
+    });
+  });
 });

--- a/src/markdown-pages/add-ons/velero.md
+++ b/src/markdown-pages/add-ons/velero.md
@@ -29,6 +29,10 @@ spec:
     localBucket: "local"
     resticRequiresPrivileged: true
     resticTimeout: "12h0m0s"
+    serverFlags:
+      - --log-level
+      - debug
+      - --default-restic-prune-frequency=12h
 ```
 
 flags-table

--- a/src/markdown-pages/install-with-kurl/advanced-options.md
+++ b/src/markdown-pages/install-with-kurl/advanced-options.md
@@ -265,6 +265,16 @@ The install scripts are idempotent. Re-run the scripts with different flags to c
   </td>
 </tr>
 <tr>
+  <td><code>velero-server-flags</code></td>
+  <td>Additional flags to pass to the Velero server. This is a comma-separated list of arguments.
+  <br/>
+  <br/>
+  <strong>Example:</strong>
+  <br/>
+  <code>curl https://kurl.sh/latest | sudo bash -s velero-server-flags=--log-level=debug,--default-restic-prune-frequency=12h</code>
+  </td>
+</tr>
+<tr>
   <td><code>ekco-enable-internal-load-balancer</code></td>
   <td>Run an internal load balanacer with HAProxy listening on localhost:6444 on all nodes.
   <br/>

--- a/static/versionDetails.json
+++ b/static/versionDetails.json
@@ -323,6 +323,11 @@
       "flag": "resticTimeout",
       "description": "The time interval that backups/restores of pod volumes are allowed to run before timing out. Default is '4h0m0s'",
       "type": "string"
+    },
+    {
+      "flag": "serverFlags",
+      "description": "Additional flags to pass to the Velero server. This is a comma-separated list of arguments.",
+      "type": "array[string]"
     }
   ],
   "kotsadm": [


### PR DESCRIPTION
This PR adds support to kurl.sh for a `serverFlags` field in the Velero add-on.  See https://github.com/replicatedhq/kURL/pull/3971 for implementation details.

[SC-35682](https://app.shortcut.com/replicated/story/35682/deleting-snapshot-does-not-reclaim-space-from-restic-for-5-days)

Support was added for `array[string]` fields where the value is input as a comma-separated list of values.

Example:

![server-flags-input](https://user-images.githubusercontent.com/17422963/214084569-34d2d5df-7497-47eb-a452-0ad7ee5d67a1.png)
