### PR TITLE
chore: remove flannel beta designation, make default cni

### DIFF
--- a/src/components/App.js
+++ b/src/components/App.js
@@ -262,6 +262,8 @@ cat install.sh | sudo bash -s airgap
                   </p>
                   {installerData.spec.kubernetes &&
                     <AppVersionCard selectedSpec={selectedSpec} name={"kubernetes"} installerData={installerData.spec.kubernetes} whatYouGet={this.whatYouGet} />}
+                  {installerData.spec.flannel &&
+                    <AppVersionCard selectedSpec={selectedSpec} name={"flannel"} installerData={installerData.spec.flannel} whatYouGet={this.whatYouGet} />}
                   {installerData.spec.weave &&
                     <AppVersionCard selectedSpec={selectedSpec} name={"weave"} installerData={installerData.spec.weave} whatYouGet={this.whatYouGet} />}
                   {installerData.spec.contour &&

--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -1251,7 +1251,6 @@ class Kurlsh extends React.Component {
                   addOnId="flannel"
                   addOnTitle="Flannel"
                   addOnIcon="u-kubernetes"
-                  isBeta={true}
                   isAddOnChecked={isAddOnChecked["flannel"]}
                   options={versions.flannel}
                   getOptionLabel={this.getLabel("flannel")}

--- a/src/markdown-pages/add-ons/flannel.md
+++ b/src/markdown-pages/add-ons/flannel.md
@@ -48,6 +48,7 @@ This can be overridden using the `podCIDR` to specify a specific address space, 
 
 ## Limitations
 
+* Flannel is not compatible with the Docker container runtime
 * Migrations from Antrea CNI are not supported
 * Network Policies are not supported
 * IPv6 and dual stack networks are not supported

--- a/src/markdown-pages/add-ons/flannel.md
+++ b/src/markdown-pages/add-ons/flannel.md
@@ -5,7 +5,6 @@ linktitle: "Flannel"
 weight: 38
 title: "Flannel Add-On"
 addOn: "flannel"
-isBeta: true
 ---
 
 [Flannel](https://github.com/flannel-io/flannel) implements the Container Network Interface (CNI) to enable pod networking in a Kubernetes cluster.
@@ -49,7 +48,6 @@ This can be overridden using the `podCIDR` to specify a specific address space, 
 
 ## Limitations
 
-* Migrations from Weave CNI are not supported
 * Migrations from Antrea CNI are not supported
 * Network Policies are not supported
 * IPv6 and dual stack networks are not supported

--- a/src/markdown-pages/add-ons/kotsadm.md
+++ b/src/markdown-pages/add-ons/kotsadm.md
@@ -56,7 +56,7 @@ spec:
     version: latest
   containerd:
     version: latest
-  weave:
+  flannel:
     version: latest
   rook:
     version: latest
@@ -78,7 +78,7 @@ spec:
     version: latest
   containerd:
     version: latest
-  weave:
+  flannel:
     version: latest
   openebs:
     version: latest
@@ -102,10 +102,12 @@ spec:
     version: latest
   docker:
     version: latest
-  weave:
+  flannel:
     version: latest
-  longhorn:
+  openebs:
     version: latest
+    isLocalPVEnabled: true
+    localPVStorageClassName: default
   registry:
     version: latest
   kotsadm:

--- a/src/markdown-pages/create-installer/host-preflights/index.md
+++ b/src/markdown-pages/create-installer/host-preflights/index.md
@@ -44,6 +44,7 @@ For each of the add-ons that you are using that have default host preflight chec
 
 For example, if your installer includes KOTS version 1.59.0, you would find the host preflight file at this link: https://github.com/replicatedhq/kURL/blob/main/addons/kotsadm/1.59.0/host-preflight.yaml.
 
+Flannel: https://github.com/replicatedhq/kURL/tree/main/addons/flannel<br>
 Weave: https://github.com/replicatedhq/kURL/tree/main/addons/weave<br>
 Rook: https://github.com/replicatedhq/kURL/tree/main/addons/rook<br>
 OpenEBS: https://github.com/replicatedhq/kURL/tree/main/addons/openebs<br>

--- a/src/markdown-pages/create-installer/index.md
+++ b/src/markdown-pages/create-installer/index.md
@@ -16,8 +16,8 @@ metadata:
 spec:
   kubernetes:
     version: "1.25.x"
-  weave:
-    version: "2.6.x"
+  flannel:
+    version: "0.20.x"
   contour:
     version: "1.22.x"
   minio:

--- a/src/markdown-pages/install-with-kurl/cis-compliance.md
+++ b/src/markdown-pages/install-with-kurl/cis-compliance.md
@@ -39,8 +39,8 @@ spec:
  kubernetes:
    version: "1.23.x"
    cisCompliance: true
- weave:
-   version: "2.6.x"
+ flannel:
+   version: "0.20.x"
  contour:
    version: "1.20.x"
  prometheus:

--- a/src/markdown-pages/install-with-kurl/index.md
+++ b/src/markdown-pages/install-with-kurl/index.md
@@ -138,8 +138,8 @@ An example of how `latest` can be used in a spec is:
   spec:
     kubernetes:
       version: "1.25.x"
-    weave:
-      version: "2.6.x"
+    flannel:
+      version: "0.20.x"
     contour:
       version: "1.22.x"
     minio:
@@ -261,7 +261,7 @@ If not available, the installer will attempt to find an available range with pre
   spec:
     kubernetes:
       serviceCIDR: "<your custom subnet>"
-    weave:     
+    flannel:     
       podCIDR: "<your custom subnet>"
 ```
 

--- a/src/markdown-pages/install-with-kurl/ipv6.md
+++ b/src/markdown-pages/install-with-kurl/ipv6.md
@@ -23,25 +23,23 @@ spec:
   kurl:
     ipv6: true
   kubernetes:
-    version: "1.23.x"
+    version: "1.26.x"
   kotsadm:
-    version: "latest"
+    version: "1.93.0"
   antrea:
-    version: "latest"
-  contour:
-    version: "1.20.x"
-  prometheus:
-    version: "0.53.x"
-  registry:
-    version: "2.7.x"
-  containerd:
     version: "1.4.x"
+  contour:
+    version: "1.23.x"
+  prometheus:
+    version: "0.60.x"
+  registry:
+    version: "2.8.x"
+  containerd:
+    version: "1.6.x"
   ekco:
     version: "latest"
-  minio:
-    version: "2020-01-25T02-50-51Z"
-  longhorn:
-    version: "1.2.x"
+  rook:
+    version: "1.10.x"
 ```
 
 There is no auto-detection of ipv6 or fall-back to ipv4 when ipv6 is not enabled on the host.
@@ -61,7 +59,7 @@ There is no auto-detection of ipv6 or fall-back to ipv4 when ipv6 is not enabled
 
 * IPv6 forwarding must be enabled and bridge-call-nf6tables must be enabled. The installer does this automatically and configures this to persist after reboots.
 
-* Using antrea, TCP 8091 and UDP 6081 have to be open between nodes instead of the ports used by weave (6784 and 6783). Antrea with encryption requires UDP port 51820 be open between nodes for wireguard and that the wireguard kernel module be available.
+* Using antrea, TCP 8091 and UDP 6081 have to be open between nodes instead of the ports used by Flannel (UDP 8472). Antrea with encryption requires UDP port 51820 be open between nodes for wireguard and that the wireguard kernel module be available.
 
 * The ip6_tables kernel module must be available. The installer configures this to be loaded automatically.
 

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -22,8 +22,8 @@ spec:
     version: 1.19.12
   docker:
     version: 20.10.5
-  weave:
-    version: 2.6.5
+  flannel:
+    version: 0.20.2
   rook:
     version: 1.0.4
 ```
@@ -40,8 +40,8 @@ spec:
     version: 1.19.12
   docker:
     version: 20.10.5
-  weave:
-    version: 2.6.5
+  flannel:
+    version: 0.20.2
   openebs:
     version: 3.3.0
     isLocalPVEnabled: true
@@ -59,10 +59,12 @@ spec:
     version: 1.19.12
   docker:
     version: 20.10.5
-  weave:
-    version: 2.6.5
-  longhorn:
-    version: 1.1.2
+  flannel:
+    version: 0.20.2
+  openebs:
+    version: 3.3.0
+    isLocalPVEnabled: true
+    localPVStorageClassName: default
   minio:
     version: 2020-01-25T02-50-51Z
 ```

--- a/src/markdown-pages/install-with-kurl/migrating.md
+++ b/src/markdown-pages/install-with-kurl/migrating.md
@@ -38,7 +38,7 @@ For information about how to change the CSI from Rook to Longhorn or OpenEBS, se
 
 ## Example Old and New Specs
 
-In the new spec, the Kubernetes version has been upgraded to 1.21, Rook has been replaced with Longhorn and Minio, Weave has been replaced with Antrea, and docker has been replaced with containerd.
+In the new spec, the Kubernetes version has been upgraded to 1.21, Longhorn has been replaced with OpenEBS, Weave has been replaced with Flannel, and docker has been replaced with containerd.
 
 ### Old
 
@@ -54,8 +54,10 @@ spec:
     version: 20.10.5
   weave:
     version: 2.6.5
-  rook:
-    version: 1.0.4
+  longhorn:
+    version: 1.3.1
+  minio:
+    version: 2020-01-25T02-50-51Z
   registry:
     version: 2.7.1
   kotsadm:
@@ -73,19 +75,21 @@ metadata:
   name: new
 spec:
   kubernetes:
-    version: 1.21.2
+    version: 1.21.14
   containerd:
-    version: 1.4.6
-  antrea:
-    version: 1.1.0
-  longhorn:
-    version: 1.1.1
+    version: 1.6.15
+  flannel:
+    version: 0.20.2
+  openebs:
+    version: 3.3.0
+    isLocalPVEnabled: true
+    localPVStorageClassName: default
   minio:
-    version: 2020-01-25T02-50-51Z
+    version: 2023-01-25T00-19-54Z
   registry:
-    version: 2.7.1
+    version: 2.8.1
   kotsadm:
-    version: 1.45.0
+    version: 1.93.0
   velero:
-    version: 1.6.1
+    version: 1.9.5
 ```

--- a/src/markdown-pages/install-with-kurl/removing-object-storage.md
+++ b/src/markdown-pages/install-with-kurl/removing-object-storage.md
@@ -24,19 +24,21 @@ metadata:
   name: no-object-storage
 spec:
   kubernetes:
-    version: 1.21.x
+    version: 1.26.x
   containerd:
-    version: 1.4.x
-  weave:
-    version: 2.6.5
-  longhorn:
-    version: 1.2.x
+    version: 1.6.x
+  flannel:
+    version: 0.20.x
+  openebs:
+    version: 3.3.x
+    isLocalPVEnabled: true
+    localPVStorageClassName: default
   registry:
-    version: 2.5.7
+    version: 2.8.x
   velero:
-    version: 1.7.x
+    version: 1.9.x
   kotsadm:
-    version: 1.58.x
+    version: 1.93.x
     disableS3: true
 ```
 

--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -97,7 +97,7 @@ The following ports must be open between nodes for multi-node clusters:
 | UDP      | Inbound   | 6783-6784  | Weave Net data               | All     |
 | TCP      | Inbound   | 9090       | Rook CSI RBD Plugin Metrics  | All     |
 
-These ports are required for [Kubernetes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#control-plane-node-s) and [Weave Net](https://www.weave.works/docs/net/latest/faq/#ports).
+These ports are required for [Kubernetes](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/install-kubeadm/#control-plane-node-s), [Flannel](https://github.com/flannel-io/flannel/blob/master/Documentation/backends.md#vxlan), and [Weave Net](https://www.weave.works/docs/net/latest/faq/#ports).
 
 ### Ports Available
 

--- a/src/markdown-pages/introduction/index.md
+++ b/src/markdown-pages/introduction/index.md
@@ -6,7 +6,7 @@ linktitle: "Overview"
 title: "Introduction to kURL"
 ---
 
-The Kubernetes URL Creator is a framework for creating custom Kubernetes distributions. These distros can then be shared as URLs (to install via `curl` and `bash`) or as downloadable packages (to install in airgapped environments). kURL relies on [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/) to bring up the Kubernetes control plane, but there are a variety of tasks a system administrator must perform both before and after running kubeadm init in order to have a production-ready Kubernetes cluster. kURL is open source, with a growing list of [add-on components](/add-ons) (including Rook, Weave, Contour, Prometheus, and more) which is easily extensible by [contributing additional add-ons](/docs/add-on-author/).
+The Kubernetes URL Creator is a framework for creating custom Kubernetes distributions. These distros can then be shared as URLs (to install via `curl` and `bash`) or as downloadable packages (to install in airgapped environments). kURL relies on [kubeadm](https://kubernetes.io/docs/reference/setup-tools/kubeadm/kubeadm/) to bring up the Kubernetes control plane, but there are a variety of tasks a system administrator must perform both before and after running kubeadm init in order to have a production-ready Kubernetes cluster. kURL is open source, with a growing list of [add-on components](/add-ons) (including Rook, Flannel, Contour, Prometheus, and more) which is easily extensible by [contributing additional add-ons](/docs/add-on-author/).
 
 ## kURL vs. Standard Distros  
 ### Production Grade Upstream Kubernetes

--- a/src/markdown-pages/introduction/what-kurl-does.md
+++ b/src/markdown-pages/introduction/what-kurl-does.md
@@ -30,12 +30,12 @@ kURL will perform the following steps on the host prior to delegating to `kubead
 * Configure Docker/containerd and Kubernetes to work behind a proxy if detected
 
 ## After kubeadm (Adding Add-Ons)
-Once kubeadm gets the cluster running, it’s not ready for an application yet. A cluster will need networking, storage and more. These services are provided by other open source components, including a lot of the CNCF ecosystem. In a kURL installation manifest, you can specify the additional add-ons that are installed after kubectl starts the cluster. For example, you can include Weave for a CNI plugin, Rook for distributed storage, Prometheus for monitoring and Fluentd for log aggregation. In addition to specifying the add-ons and versions, most add-ons include advanced options that allow you to specify the initial configuration.
+Once kubeadm gets the cluster running, it’s not ready for an application yet. A cluster will need networking, storage and more. These services are provided by other open source components, including a lot of the CNCF ecosystem. In a kURL installation manifest, you can specify the additional add-ons that are installed after kubectl starts the cluster. For example, you can include Flannel for a CNI plugin, Rook for distributed storage, Prometheus for monitoring and Fluentd for log aggregation. In addition to specifying the add-ons and versions, most add-ons include advanced options that allow you to specify the initial configuration.
 
 After `kubeadm init` has brought up the Kubernetes control plane, kURL will install add-ons into the cluster.
 The available add-ons are:
 
-* [Weave](https://www.weave.works/oss/net/)
+* [Flannel](https://github.com/flannel-io/flannel/releases)
 * [Contour](https://projectcontour.io/)
 * [OpenEBS](https://openebs.io/)
 * [Rook](https://rook.io/)
@@ -49,4 +49,4 @@ The available add-ons are:
 * [Velero](https://velero.io/)
 * [EKCO](https://github.com/replicatedhq/ekco)
 * [Sonobuoy](https://github.com/vmware-tanzu/sonobuoy/releases)
-* [Cert Mnager](https://github.com/cert-manager/cert-manager)
+* [Cert Manager](https://github.com/cert-manager/cert-manager)

--- a/src/markdown-pages/introduction/what-kurl-does.md
+++ b/src/markdown-pages/introduction/what-kurl-does.md
@@ -30,7 +30,7 @@ kURL will perform the following steps on the host prior to delegating to `kubead
 * Configure Docker/containerd and Kubernetes to work behind a proxy if detected
 
 ## After kubeadm (Adding Add-Ons)
-Once kubeadm gets the cluster running, it’s not ready for an application yet. A cluster will need networking, storage and more. These services are provided by other open source components, including a lot of the CNCF ecosystem. In a kURL installation manifest, you can specify the additional add-ons that are installed after kubectl starts the cluster. For example, you can include Flannel for a CNI plugin, Rook for distributed storage, Prometheus for monitoring and Fluentd for log aggregation. In addition to specifying the add-ons and versions, most add-ons include advanced options that allow you to specify the initial configuration.
+Once kubeadm gets the cluster running, it’s not ready for an application yet. A cluster will need networking, storage and more. These services are provided by other open source components, many of them from the CNCF ecosystem. In a kURL installation manifest, you can specify the additional add-ons that are installed after kubectl starts the cluster. For example, you can include Flannel for a CNI plugin, Rook for distributed storage, Prometheus for monitoring and Fluentd for log aggregation. In addition to specifying the add-ons and versions, most add-ons include advanced options that allow you to specify the initial configuration.
 
 After `kubeadm init` has brought up the Kubernetes control plane, kURL will install add-ons into the cluster.
 The available add-ons are:


### PR DESCRIPTION
Removes Flannel beta designation.

Refers to Flannel in example specs rather than Weave in preparation for making Flannel the default CNI.