### PR TITLE
Add warning about purging a node

### DIFF
--- a/src/markdown-pages/add-ons/ekco.md
+++ b/src/markdown-pages/add-ons/ekco.md
@@ -92,6 +92,8 @@ Global Flags:
       --log_level string   Log level (default "info")
 ```
 
+⚠️ _**Warning**:_ Purging a node is an irrevocable operation and is meant to permanently remove the node from the cluster with the expectation that it will never become a member again.
+
 ### Rook
 
 The EKCO operator is responsible for appending nodes to the CephCluster `storage.nodes` setting to include the node in the list of nodes used by Ceph for storage. This operation only appends nodes. Removing nodes is done during the purge.


### PR DESCRIPTION
Clarify expectations about the `ekco-purge-node` command. Users  _should_ not expect to purge a node from a cluster and expect the same node to be added to the cluster again.