### PR TITLE
feat: enable austere linter for kurl.sh.

### DIFF
--- a/src/components/Kurlsh.js
+++ b/src/components/Kurlsh.js
@@ -841,7 +841,9 @@ class Kurlsh extends React.Component {
 
   postToKurlInstaller = async (yaml) => {
     this.setState({ installerErrMsg: "" })
-    const url = `${process.env.KURL_INSTALLER_URL}`
+    let parsedURL = new URL(process.env.KURL_INSTALLER_URL);
+    parsedURL.searchParams.append('austere', true);
+    const url = parsedURL.toString();
     try {
       const response = await fetch(url, {
         method: "POST",


### PR DESCRIPTION
### What has been introduced by this PR

Enables the kurl-api `austere` Installer linter.

### Why has been done

The new linter has been hidden behind this flag for a long time, in the past we had to hide it due of: 

1) The initial implementation was incomplete (missed the `skip_validation` flag implementation).
2) A [bug ](https://github.com/replicatedhq/cloudflare-workers/pull/251)in one of our `cloudflare-workers`.

Since then the new linter has been enabled as part of the `kots-lint` project and became active in the vendor portal. This is an example of how the new linter complains are presented in the vendor portal:

<img width="925" alt="Screenshot 2023-02-23 at 14 32 27" src="https://user-images.githubusercontent.com/1385436/220921261-b53dced0-1efd-45d9-a8d4-ab9f48bbe324.png">

### Impact

Even though the new linter may return multiple complaints at the same time `kurl.sh` interface is prepared to receive only one complain at a time. Due to that limitation additional complains are being [trimmed off](https://github.com/replicatedhq/kURL-api/blob/main/cmd/server/main.go#L179-L188) by `kurl-api`. Allied to that the `austere` flag is not known or used by any other project so the only usage will be done here, by `kurl.sh`. The test deployment available [here](https://63f760da6bb42c004eee0a8b--kurlsh-staging.netlify.app/) does not show any issues.


