### PR TITLE
doc: documenting containerd upgrade constraints.

### DIFF
--- a/src/markdown-pages/add-ons/containerd.md
+++ b/src/markdown-pages/add-ons/containerd.md
@@ -13,6 +13,10 @@ As CentOS, RHEL and Oracle Linux 8.x do not support Docker, the Containerd CRI i
 
 Containerd 1.4.8+ has dropped support for Ubuntu 16.04.
 
+### About Containerd upgrades
+
+If you are planning to upgrade your Containerd installation, it is highly recommended that you refer to the relevant [documentation page](/docs/install-with-kurl/upgrading#about-containerd-upgrades) for guidance and best practices.
+
 ## Advanced Install Options
 
 ```yaml

--- a/src/markdown-pages/install-with-kurl/upgrading.md
+++ b/src/markdown-pages/install-with-kurl/upgrading.md
@@ -26,6 +26,12 @@ For example, if you have a cluster using Containerd version `1.6.4` and then you
 
 Also, be aware that Docker is not supported with Kubernetes versions 1.24+. Therefore, it is recommended to use Containerd instead. You can upgrade your installation by replacing Docker in your spec with Containerd. If the install script detects a change from Docker to Containerd, it will install Containerd, load the images found in Docker, and remove Docker.
 
+### About Containerd upgrades
+
+The Kurl installers offer a practical solution to the challenge of upgrading Containerd installations that span more than one minor release, despite Containerd not providing official support for this upgrade path. With its automated processes that facilitate such upgrades, Kurl enables users to upgrade their Containerd installations seamlessly, even if spanning two minor releases. This ensures that the upgrade process is streamlined, enabling a smoother transition to the latest version of Containerd.
+
+It is worth noting that while it is possible to upgrade Containerd directly from version 1.3.x to 1.5.x, attempting to upgrade across more than two minor releases, such as upgrading from version 1.3.x to 1.6.x, will result in an upgrade error. Therefore, it is highly recommended that users follow the supported upgrade paths to ensure a successful upgrade of their cluster. By adhering to the supported upgrade paths, you can avoid potential issues and successfully upgrade your Containerd installation.
+
 ## Airgap
 
 Because upgraded components may have pods scheduled on any node in the cluster, images must be pre-loaded on every node prior to running the updated installer.

--- a/src/markdown-pages/install-with-kurl/upgrading.md
+++ b/src/markdown-pages/install-with-kurl/upgrading.md
@@ -28,7 +28,7 @@ Also, be aware that Docker is not supported with Kubernetes versions 1.24+. Ther
 
 ### About Containerd upgrades
 
-The Kurl installers offer a practical solution to the challenge of upgrading Containerd installations that span more than one minor release, despite Containerd not providing official support for this upgrade path. With its automated processes that facilitate such upgrades, Kurl enables users to upgrade their Containerd installations seamlessly, even if spanning two minor releases. This ensures that the upgrade process is streamlined, enabling a smoother transition to the latest version of Containerd.
+The Kurl installers offers a practical solution to the challenge of upgrading Containerd installations that span more than one minor release, despite Containerd not providing official support for this upgrade path. With its automated processes that facilitate such upgrades, Kurl enables users to upgrade their Containerd installations seamlessly, even if spanning two minor releases. This ensures that the upgrade process is streamlined, enabling a smoother transition to the latest version of Containerd.
 
 It is worth noting that while it is possible to upgrade Containerd directly from version 1.3.x to 1.5.x, attempting to upgrade across more than two minor releases, such as upgrading from version 1.3.x to 1.6.x, will result in an upgrade error. Therefore, it is highly recommended that users follow the supported upgrade paths to ensure a successful upgrade of their cluster. By adhering to the supported upgrade paths, you can avoid potential issues and successfully upgrade your Containerd installation.
 


### PR DESCRIPTION
document kurl supports containerd upgrades that span up to two minor releases.