### PR TITLE
docs: Update kots disableS3 flag description

### DIFF
--- a/static/versionDetails.json
+++ b/static/versionDetails.json
@@ -363,7 +363,7 @@
     },
     {
       "flag": "disableS3",
-      "description": "Migrate application archives and support bundles from S3 and use a local volume in the kotsadm statefulset instead. Also changes nfs and hostpath snapshots from using minio to using the local-volume-provider plugin. The migration process is irreversible and will replace the kotsadm deployment with a statefulset. While this reduces KOTS's dependency on an object store for the application archives and support bundles, an object store is still required to deploy KOTS. Defaults to 'false.'",
+      "description": "Migrate application archives and support bundles from S3 and use a local volume in the kotsadm statefulset instead. Also changes nfs and hostpath snapshots from using minio to using the local-volume-provider plugin. The migration process is irreversible and will replace the kotsadm deployment with a statefulset. This reduces KOTS's dependency to an object store for the application archives and support bundle archives. Defaults to 'false.'",
       "type": "boolean"
     }
   ],


### PR DESCRIPTION
Remove the statement that implies that the object store is required.