### PR TITLE
docs: migrating csi - add info to ensure that the cluster and storage solutions are health prior migrations

### DIFF
--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -74,6 +74,11 @@ Before you attempt to change the CSI provisioner in your cluster, complete the f
 
 - The add-ons Kots and Registry require an Object Storage API (similar to AWS S3) to be available in the cluster. This API can be provided either by Rook (directly) or by the OpenEBS+Minio duo (OpenEBS provides the storage and Minio the Object Storage API). If you are using Kots or Registry add-ons in your cluster then the available migration paths are to migrate to Rook or to OpenEBS+Minio.
 
+- Ensure that cluster is a healthy state prior do any migration. Check if the Nodes are Ready and if all Pods are running. Also, if you are migrating from an storage solution to another please ensure that it is healthy prior the migration. Beyond check if all Pod(s) into this namespace are Running you might want check the storage state:
+
+  - If you are migrating from Rook Ceph then, see [Health Verification](https://rook.io/docs/rook/v1.11/Upgrade/health-verification/#upgrading-an-unhealthy-cluster) in the Rook Ceph documentation.
+  - If you are migration from OpenEBS then, see [How to verify whether cStor volume is running fine?](https://openebs.io/docs/additional-info/kb#how-to-verify-whether-cstor-volume-is-running-fine) to know how to verify the volumes.
+  
 ### Longhorn Prerequisites
 
 If you are migrating from Longhorn to a different CSI provisioner, you must complete the following prerequisites in addition to the [General Prerequisites](#general-prerequisites) above:

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -74,7 +74,7 @@ Before you attempt to change the CSI provisioner in your cluster, complete the f
 
 - The add-ons Kots and Registry require an Object Storage API (similar to AWS S3) to be available in the cluster. This API can be provided either by Rook (directly) or by the OpenEBS+Minio duo (OpenEBS provides the storage and Minio the Object Storage API). If you are using Kots or Registry add-ons in your cluster then the available migration paths are to migrate to Rook or to OpenEBS+Minio.
 
-- Ensure that cluster is a healthy state prior to perform any migration. Check if the Nodes are Ready and if all Pods are running. Also, if you are migrating from an storage solution to another please ensure that it is healthy. To do perform this checks see:
+- Ensure that cluster is a healthy state prior to perform any migration. Check if the Nodes are Ready and if all Pods are running. Also, if you are migrating from an storage solution to another please ensure that it is healthy. To perform these checks see:
 
   - If you are migrating from Rook Ceph then, see [Health Verification](https://rook.io/docs/rook/v1.11/Upgrade/health-verification/#upgrading-an-unhealthy-cluster) in the Rook Ceph documentation.
   - If you are migration from OpenEBS then, see [How to verify whether cStor volume is running fine?](https://openebs.io/docs/additional-info/kb#how-to-verify-whether-cstor-volume-is-running-fine) to know how to verify the volumes.

--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -74,7 +74,7 @@ Before you attempt to change the CSI provisioner in your cluster, complete the f
 
 - The add-ons Kots and Registry require an Object Storage API (similar to AWS S3) to be available in the cluster. This API can be provided either by Rook (directly) or by the OpenEBS+Minio duo (OpenEBS provides the storage and Minio the Object Storage API). If you are using Kots or Registry add-ons in your cluster then the available migration paths are to migrate to Rook or to OpenEBS+Minio.
 
-- Ensure that cluster is a healthy state prior do any migration. Check if the Nodes are Ready and if all Pods are running. Also, if you are migrating from an storage solution to another please ensure that it is healthy prior the migration. Beyond check if all Pod(s) into this namespace are Running you might want check the storage state:
+- Ensure that cluster is a healthy state prior to perform any migration. Check if the Nodes are Ready and if all Pods are running. Also, if you are migrating from an storage solution to another please ensure that it is healthy. To do perform this checks see:
 
   - If you are migrating from Rook Ceph then, see [Health Verification](https://rook.io/docs/rook/v1.11/Upgrade/health-verification/#upgrading-an-unhealthy-cluster) in the Rook Ceph documentation.
   - If you are migration from OpenEBS then, see [How to verify whether cStor volume is running fine?](https://openebs.io/docs/additional-info/kb#how-to-verify-whether-cstor-volume-is-running-fine) to know how to verify the volumes.


### PR DESCRIPTION
… 

To add info to ensure that the cluster and storage solutions are health prior migrations