### PR TITLE
chore(actions): deprecate set-output

### DIFF
--- a/.github/workflows/update-release-notes.yaml
+++ b/.github/workflows/update-release-notes.yaml
@@ -15,8 +15,8 @@ jobs:
         KURL_VERSION: ${{ github.event.client_payload.version }}
       run: |
         KURL_VERSION=$( echo $KURL_VERSION | sed -E -e 's/v(.*)/\1/g' )
-        echo "::set-output name=parsed_kurl_version::$KURL_VERSION"
-        
+        echo "parsed_kurl_version=$KURL_VERSION" >> "$GITHUB_OUTPUT"
+
         cp ./hack/release-notes.md.tmpl ./src/release-notes/${KURL_VERSION}.md
         DATE=$(date +%F)
         WEIGHT=$(echo $KURL_VERSION | tr -d "v\.\-")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines here:
https://github.com/replicatedhq/kURL/blob/main/CONTRIBUTING.md.
2. If the PR is unfinished, please mark it as a draft.
3. Set the label on the pull request.
-->

#### What this PR does / why we need it:

A workflow using save-state or set-output like the following should be updated to write to the new GITHUB_STATE and GITHUB_OUTPUT environment files.

https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/