### PR TITLE
chore: update list of supported operating systems

### DIFF
--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -8,13 +8,13 @@ title: "System Requirements"
 
 ## Supported Operating Systems
 
-* Ubuntu 18.04
+* Ubuntu 18.04<sup>\*</sup>
 * Ubuntu 20.04 (Docker version >= 19.03.10)
 * Ubuntu 22.04 (Requires Containerd version >= 1.5.10 or Docker version >= 20.10.17. Collectd add-ons are not supported.)
 * CentOS 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1<sup>\*</sup>, 8.2<sup>\*</sup>, 8.3<sup>\*</sup>, 8.4<sup>\*</sup> (CentOS 8.x requires Containerd)
-* RHEL 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8, 9.0, 9.1, 9.2 (RHEL 8.x and 9.x require Containerd)
-* Rocky Linux 9.0, 9.1, 9.2 (Rocky Linux 9.x requires Containerd)
-* Oracle Linux 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8 (OL 8.x requires Containerd)
+* RHEL 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0<sup>\*</sup>, 8.1<sup>\*</sup>, 8.2<sup>\*</sup>, 8.3<sup>\*</sup>, 8.4<sup>\*</sup>, 8.5<sup>\*</sup>, 8.6, 8.7<sup>\*</sup>, 8.8, 9.0, 9.1<sup>\*</sup>, 9.2 (RHEL 8.x and 9.x require Containerd)
+* Rocky Linux 9.0<sup>\*</sup>, 9.1<sup>\*</sup>, 9.2 (Rocky Linux 9.x requires Containerd)
+* Oracle Linux 7.4<sup>\*</sup>, 7.5<sup>\*</sup>, 7.6<sup>\*</sup>, 7.7<sup>\*</sup>, 7.8<sup>\*</sup>, 7.9, 8.0, 8.1, 8.2, 8.3, 8.4, 8.5, 8.6, 8.7, 8.8 (OL 8.x requires Containerd)
 * Amazon Linux 2
 
 *&ast; This version is deprecated since it is no longer supported by its creator. We continue to support it, but support will be removed in the future.*


### PR DESCRIPTION
updates the list of supported operating system by flagging the ones that are not supported upstream anymore.

oracle linux 8.0 seems to be yet [supported](https://www.oracle.com/a/ocom/docs/elsp-lifetime-069338.pdf) so this commit also adjusts this hickup.