### PR TITLE
doc: update Velero config with new restic flag

### DIFF
--- a/src/markdown-pages/add-ons/velero.md
+++ b/src/markdown-pages/add-ons/velero.md
@@ -38,7 +38,7 @@ spec:
     serverFlags:
       - --log-level
       - debug
-      - --default-restic-prune-frequency=12h
+      - --default-repo-maintain-frequency=12h
 ```
 
 flags-table

--- a/src/markdown-pages/install-with-kurl/advanced-options.md
+++ b/src/markdown-pages/install-with-kurl/advanced-options.md
@@ -261,7 +261,7 @@ The install scripts are idempotent. Re-run the scripts with different flags to c
   <br/>
   <strong>Example:</strong>
   <br/>
-  <code>curl https://kurl.sh/latest | sudo bash -s velero-server-flags=--log-level=debug,--default-restic-prune-frequency=12h</code>
+  <code>curl https://kurl.sh/latest | sudo bash -s velero-server-flags=--log-level=debug,--default-repo-maintain-frequency=12h</code>
   </td>
 </tr>
 <tr>


### PR DESCRIPTION
There's a breaking change from Velero `1.10`

https://github.com/vmware-tanzu/velero/blob/main/changelogs/CHANGELOG-1.10.md#breaking-changes

>restic daemonset is renamed to node-agent resticRepository CR is renamed to backupRepository velero restic repo command is renamed to velero repo velero-restic-credentials secret is renamed to velero-repo-credentials default-volumes-to-restic parameter is renamed to default-volumes-to-fs-backup restic-timeout parameter is renamed to fs-backup-timeout default-restic-prune-frequency parameter is renamed to default-repo-maintain-frequency

Our default advanced spec has `--default-restic-prune-frequency=12h` which will cause the installation to be failed with pod error `An error occurred: unknown flag: --default-restic-prune-frequency`

I have updated the doc with the new flag.

