### PR TITLE
chore: update cis docs to meet 1.8 benchmarks

### DIFF
--- a/src/markdown-pages/install-with-kurl/cis-compliance.md
+++ b/src/markdown-pages/install-with-kurl/cis-compliance.md
@@ -6,7 +6,7 @@ linktitle: "CIS Compliance"
 title: "CIS Compliance"
 isAlpha: false
 ---
-You can configure the kURL installer to be Center for Internet Security (CIS) compliant. Opt-in to this feature by setting the `kurl.cisCompliance` field to `true` in the kURL specification. For information about known limitations, see [Known Limitations](#known-limitations). For more information about CIS security compliance for Kubernetes, see the [CIS benchmark information](https://www.cisecurity.org/benchmark/kubernetes).
+You can configure the kURL installer to be Center for Internet Security (CIS) compliant for versions up to CIS 1.8. Opt-in to this feature by setting the `kurl.cisCompliance` field to `true` in the kURL specification. For information about known limitations, see [Known Limitations](#known-limitations). For more information about CIS security compliance for Kubernetes, see the [CIS benchmark information](https://www.cisecurity.org/benchmark/kubernetes).
 
 When you set `cisCompliance` is set to `true`, the following settings are changed from the default settings:
 
@@ -62,15 +62,26 @@ spec:
 
 * The [EKCO add-on](/docs/add-ons/ekco) v0.19.0 and later is required to use this feature.
 * This feature works with the [Kubernetes (kubeadm) add-on](https://kurl.sh/docs/add-ons/kubernetes) only.
-* To meet CIS compliance, admin.conf permissions are changed from the default `root:sudo 440` to `root:root 400`.
+* To meet CIS compliance, admin.conf and super-admin.conf permissions are changed from the default `root:sudo 440` to `root:root 400` and `root:root 600` respectively.
 * Kubelet no longer attempts to change kernel parameters at runtime. Using kernel parameters other than those expected by Kubernetes can block kubelet from initializing and causes the installation to fail.
 * This feature has been tested with kURL upgrades, however we strongly recommend testing this with your development environments prior to upgrading production.
-* The following failure was identified in kURL testing with `kube-bench` v0.6.8 and is believed to be due to the etcd user not being listed in /etc/passwd mounted from the host:
-    ```bash
-    [FAIL] 1.1.12 Ensure that the etcd data directory ownership is set to etcd:etcd (Automated)
-    ```
-    * **Note:** This check only fails when `kube-bench` is deployed as a Kubernetes job running on a control plane node.
-    * For more information about the etcd data directory ownership check failure issue, see [this issue in GitHub](https://github.com/aquasecurity/kube-bench/issues/1221).
+
+## Running kube-bench
+
+Below are instructions for running the CIS 1.8 Kubernetes Benchmark checks for Kubernetes versions 1.26 through 1.31 using kube-bench.
+
+Download the kube-bench binary:
+
+```bash
+curl -LO https://github.com/aquasecurity/kube-bench/releases/download/v0.8.0/kube-bench_0.8.0_linux_amd64.tar.gz
+tar xzvf kube-bench_0.8.0_linux_amd64.tar.gz
+```
+
+Run kube-bench:
+
+```bash
+sudo KUBECONFIG=/etc/kubernetes/admin.conf ./kube-bench run --config-dir=./cfg --benchmark cis-1.8
+```
 
 ## AWS Amazon Linux 2 (AL2) Considerations
 The kernel defaults of this Amazon Machine Image (AMI) are not set properly for CIS compliance. CIS compliance does not allow Kubernetes to change kernel settings itself. You must change the kernel defaults to the following settings before installing with kURL:

--- a/src/markdown-pages/install-with-kurl/cis-compliance.md
+++ b/src/markdown-pages/install-with-kurl/cis-compliance.md
@@ -6,7 +6,7 @@ linktitle: "CIS Compliance"
 title: "CIS Compliance"
 isAlpha: false
 ---
-You can configure the kURL installer to be Center for Internet Security (CIS) compliant for versions up to CIS 1.8. Opt-in to this feature by setting the `kurl.cisCompliance` field to `true` in the kURL specification. For information about known limitations, see [Known Limitations](#known-limitations). For more information about CIS security compliance for Kubernetes, see the [CIS benchmark information](https://www.cisecurity.org/benchmark/kubernetes).
+You can configure the kURL installer to be Center for Internet Security (CIS) compliant for CIS 1.8 or earlier. Opt-in to this feature by setting the `kurl.cisCompliance` field to `true` in the kURL specification. For information about known limitations, see [Known Limitations](#known-limitations). For more information about CIS security compliance for Kubernetes, see the [CIS benchmark information](https://www.cisecurity.org/benchmark/kubernetes).
 
 When you set `cisCompliance` is set to `true`, the following settings are changed from the default settings:
 


### PR DESCRIPTION
- Require CIS <= 1.8
- Add super-admin.conf
- Give kube-bench example