### PR TITLE
Adding the playwrite install to the prod deploy step

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -49,6 +49,8 @@ jobs:
           node-version: 20
           cache: yarn
 
+      - name: playwright
+        run: npx playwright install --with-deps
       - name: build
         run: make deps build-production
 


### PR DESCRIPTION
We only called the playwrite install method for the staging deploy, but not the prod deploy