### PR TITLE
Fixing dependabot/194

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "lodash": "^4.17.19",
     "monaco-editor": "^0.52.0",
     "monaco-editor-webpack-plugin": "^7.1.0",
+    "nanoid": "^3.3.8",
     "playwright": "^1.49.0",
     "prop-types": "^15.7.2",
     "puppeteer": "^7.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -11847,6 +11847,11 @@ nanoid@^3.3.7:
   resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.7.tgz#d0c301a691bc8d54efa0a2226ccf3fe2fd656bd8"
   integrity sha512-eSRppjcPIatRIMC1U6UngP8XFcz8MQWGQdt1MTBQ7NaAmvXDfvNxbvWV3x2y6CdEUciCSsDHDQZbhYaB8QEo2g==
 
+nanoid@^3.3.8:
+  version "3.3.8"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.3.8.tgz#b1be3030bee36aaff18bacb375e5cce521684baf"
+  integrity sha512-WNLf5Sd8oZxOm+TzppcYk8gVOgP+l58xNy58D0nbUnOxOWRWvlcCV4kUF7ltmI6PsrLl/BgKEyS4mqsGChFN0w==
+
 napi-build-utils@^1.0.1:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/napi-build-utils/-/napi-build-utils-1.0.2.tgz#b1fddc0b2c46e380a0b7a76f984dd47c41a13806"


### PR DESCRIPTION
Fixing dependabot/194. Making nanoid an explicit dependency. It's dependency tree is very deep and it is required by a few branches in the tree. Yarn didn't work when I tried to add it as a resolution.