### PR TITLE
chore(ci): bump the ubuntu GH runners

### DIFF
--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -11,7 +11,7 @@ jobs:
     environment:
       name: staging
       url: https://staging.kurl.sh
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,7 +43,7 @@ jobs:
     environment:
       name: production
       url: https://kurl.sh
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -8,7 +8,7 @@ on:
 jobs:
 
   deploy-staging-netlify:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -5,7 +5,7 @@ on: [ pull_request ]
 jobs:
 
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/.github/workflows/update-release-notes.yaml
+++ b/.github/workflows/update-release-notes.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   build-pr-release-notes:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v4
 


### PR DESCRIPTION
Solves the current deprecation issues we're seeing:
- https://github.com/replicatedhq/kurl.sh/actions/runs/14841911139/job/41666668625

![image](https://github.com/user-attachments/assets/e15f85d2-ff89-4e6d-b772-759de2cd3da9)
