### PR TITLE
Correcting sys-req markdown to include RHEL 9.4 as needing containerd.

### DIFF
--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -49,7 +49,7 @@ For these OSes, the following packages are required per add-on:
 | Rook                             | lvm2 |
 | Velero                           | nfs-utils |
 
-Additionally, the `containerd` package is required for Containerd add-on installations on Amazon Linux 2023 and Ubuntu 24.04.
+Additionally, the `containerd` package is required for Containerd add-on installations on Amazon Linux 2023, Ubuntu 24.04 and RHEL 9.4.
 
 In general, the latest versions of the packages listed above are recommended for installation.
 For instance, you do not need to match the version of the containerd package to the version of the containerd add-on.


### PR DESCRIPTION
Update system requirements documentation to include RHEL 9.4 for clarity

- Added RHEL 9.4 to the list of operating systems that require the 'containerd' package for Containerd add-on installations
- Maintains consistency with existing requirements for Amazon Linux 2023 and Ubuntu 24.04