### PR TITLE
chore(ci): allow netlify comments on dependabot prs

### DIFF
--- a/.github/workflows/preview.yaml
+++ b/.github/workflows/preview.yaml
@@ -5,6 +5,9 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
 
   deploy-staging-netlify:


### PR DESCRIPTION
Netlify deploy preview failing with comment permissions on dependabot prs

https://github.com/replicatedhq/kurl.sh/actions/runs/16751869045/job/47423948904?pr=1149