### PR TITLE
chore(deps): dependabot npm groups

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,6 +10,27 @@ updates:
     schedule:
       interval: "daily"
     open-pull-requests-limit: 25
+    groups:
+      security:
+        update-types:
+          - "patch"
+      gatsby:
+        patterns:
+          - "gatsby"
+          - "gatsby-*"
+      bugsnag:
+        patterns:
+          - "@bugsnag/*"
+      docsearch:
+        patterns:
+          - "docsearch*"
+      react:
+        patterns:
+          - "react"
+          - "react-dom"
+      "babel":
+        patterns:
+          - "@babel/*"
 
   - package-ecosystem: "github-actions"
     directory: "/"


### PR DESCRIPTION
There are many gatsby prs from dependabot that should be grouped. Add other groupings as well.