### PR TITLE
docs: document NodePort 31880 requirement for local-to-distributed storage migration

### DIFF
--- a/src/markdown-pages/install-with-kurl/migrating-csi.md
+++ b/src/markdown-pages/install-with-kurl/migrating-csi.md
@@ -193,6 +193,8 @@ When you include the `minimumNodeCount` field and the cluster meets the minimum 
 
 - The user runs the `migrate-multinode-storage` command in the kURL tasks.sh script from a primary node.
 
+_**Note**_: To orchestrate the migration, kURL communicates with the EKCO operator over its NodePort service on port `31880`. The `migrate-multinode-storage` command defaults to reaching the operator at `localhost:31880`, so it must be run from a node where this port is accessible (typically a primary node). Ensure that port `31880/TCP` is not blocked by a firewall or otherwise unavailable, or the migration cannot start.
+
 ### Implementation
 
 The following example spec uses the `minimumNodeCount` field to configure kURL to run local storage with OpenEBS until the cluster increases to three nodes. When the cluster increases to three nodes, kURL automatically migrates to distributed storage with Rook:
@@ -218,6 +220,7 @@ The `minimumNodeCount` field has the following requirements:
   - Rook 1.11.7 or later
   - OpenEBS 3.6.0 or later
   - Block storage devices for Rook
+  - NodePort `31880/TCP` accessible on the node where the migration is run, so that kURL can reach the EKCO operator to orchestrate the migration
 
 ### Limitation  
 


### PR DESCRIPTION
## What

Documents the NodePort `31880` requirement for automated local-to-distributed storage migrations in `migrating-csi.md`.

To orchestrate the migration, kURL communicates with the EKCO operator over its NodePort service on port `31880`. The `migrate-multinode-storage` command defaults to reaching the operator at `localhost:31880`, so it must run from a node where that port is accessible, and the port must not be firewalled.

## Changes

- Added a note in the **Automated Local to Distributed Storage Migrations** section explaining the EKCO NodePort `31880` communication path.
- Added NodePort `31880/TCP` accessibility to the **Requirements** list.

## Source references

- EKCO exposed as a NodePort service (`nodePort: $EKCO_NODE_PORT`) — `kurl/addons/ekco/template/base/service.tmpl.yaml`
- `EKCO_NODE_PORT=31880` — `kurl/addons/ekco/0.28.14/install.sh`
- `/storagemigration/*` endpoints served on `:8080` — `ekco/pkg/server/server.go`
- `migrate-multinode-storage` defaults `--ekco-address` to `localhost:31880` — `kurl/pkg/cli/cluster_migrate_multinode_storage.go`