### PR TITLE
docs: document ports 31880 (EKCO NodePort) and 10256 (kube-proxy health check)

### DIFF
--- a/src/markdown-pages/install-with-kurl/system-requirements.md
+++ b/src/markdown-pages/install-with-kurl/system-requirements.md
@@ -195,9 +195,11 @@ In addition to the ports listed above that must be open between nodes, the follo
 | 6782 | [weave](/docs/add-ons/weave) metrics server |
 | 10248 | kubelet health server |
 | 10249 | kube-proxy metrics server |
+| 10256 | kube-proxy health check server |
 | 9100 | [prometheus](/docs/add-ons/prometheus) node-exporter metrics server |
 | 10257 | kube-controller-manager health server |
 | 10259 | kube-scheduler health server |
+| 31880 | [EKCO](/docs/add-ons/ekco) operator NodePort, used by kURL to orchestrate [local-to-distributed storage migrations](/docs/install-with-kurl/migrating-csi) |
 
 ### Additional Firewall Rules
 


### PR DESCRIPTION
## What

Adds two host-local ports to the **Ports Available** table in the kURL system requirements doc:

- **`10256`** — kube-proxy health check server (grouped with the existing kubelet/kube-proxy local health and metrics ports).
- **`31880`** — EKCO operator NodePort, used by kURL to orchestrate local-to-distributed storage migrations. Links to the EKCO add-on and the migration docs.

## Why

Follow-up to #1340, which documented the `31880/TCP` requirement in `migrating-csi.md`. This surfaces both ports in the central system requirements reference so operators sizing firewall/host port availability see them in one place.

## Notes

Both ports serve local connections on the host, so they belong in the *Ports Available* table rather than the between-node firewall tables. The `migrate-multinode-storage` command reaches EKCO at `localhost:31880` from the node it runs on, consistent with how #1340 frames it.